### PR TITLE
fix: 🐛 exports correct extensions

### DIFF
--- a/.changeset/easy-geese-lose.md
+++ b/.changeset/easy-geese-lose.md
@@ -1,0 +1,5 @@
+---
+"motion-start": patch
+---
+
+export correct extensions

--- a/package.json
+++ b/package.json
@@ -13,11 +13,7 @@
 		"ur": "https://github.com/JonathonRP/motion-start.git"
 	},
 	"type": "module",
-	"files": [
-		"dist/*",
-		"!dist/**/*.test.*",
-		"!dist/**/*.spec.*"
-	],
+	"files": ["dist/*", "!dist/**/*.test.*", "!dist/**/*.spec.*"],
 	"module": "./dist/index.js",
 	"svelte": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -29,7 +25,7 @@
 		"./src/*": {
 			"types": "./dist/*.d.ts",
 			"svelte": "./dist/*.svelte",
-			"default": "./dist/*.{js|svelte}"
+			"default": "./dist/*.js"
 		}
 	},
 	"scripts": {
@@ -86,19 +82,6 @@
 		"node": ">=20"
 	},
 	"sideEffects": false,
-	"keywords": [
-		"svelte animation",
-		"svelte",
-		"animation",
-		"gestures",
-		"drag",
-		"spring",
-		"popmotion",
-		"framer-motion"
-	],
-	"trustedDependencies": [
-		"@biomejs/biome",
-		"@sveltejs/kit",
-		"esbuild"
-	]
+	"keywords": ["svelte animation", "svelte", "animation", "gestures", "drag", "spring", "popmotion", "framer-motion"],
+	"trustedDependencies": ["@biomejs/biome", "@sveltejs/kit", "esbuild"]
 }


### PR DESCRIPTION
correct exports extensions

BREAKING CHANGE: 🧨 none