### PR TITLE
fix: 🐛 svg motion element not appearing

### DIFF
--- a/.changeset/rich-monkeys-dress.md
+++ b/.changeset/rich-monkeys-dress.md
@@ -1,0 +1,5 @@
+---
+"motion-start": patch
+---
+
+fix svg not appearing with motion use

--- a/src/lib/motion-start/render/dom/Motion-Proxy.svelte
+++ b/src/lib/motion-start/render/dom/Motion-Proxy.svelte
@@ -7,14 +7,16 @@
     // let {as, class: className, children, ...restProps}: {as: keyof SvelteHTMLElements, children: Snippet, class: string } & MotionProps = $props();
     export let ___tag: keyof SvelteHTMLElements;
     export let el: SvelteHTMLElements[typeof ___tag]["this"];
+    export let isSVG: boolean;
 </script>
 
-<Motion {...$$restProps} let:props let:motion>
+<Motion {...$$restProps} let:props let:motion isSVG>
     <svelte:element
         this={___tag}
         {...props}
         bind:this={el}
         class={props.class}
+        xmnls={isSVG ? "http://www.w3.org/2000/svg" : undefined}
         use:motion
     >
         <slot />


### PR DESCRIPTION
use svelte new namespace to fix svg element with motion that is there in
html source code but does not get rendered

BREAKING CHANGE: 🧨 none