### PR TITLE
fix: target ES2022 so packaged output keeps native class fields

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
 		// "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
 		/* Language and Environment */
-		"target": "ES2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+		"target": "ES2022" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
 		// "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
 		// "jsx": "preserve",                                /* Specify what JSX code is generated. */
 		// "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */


### PR DESCRIPTION
## Problem

The published package fails to compile in consumers. Anything that pulls in the projection node — i.e. any use of layout animations — hits:

```
[plugin:vite-plugin-svelte] state_invalid_placement
`$state(...)` can only be used as a variable declaration initializer or a class field
```

This reproduces against `motion-start@0.2.0-next.0` from npm.

## Cause

The root `tsconfig.json` sets `"target": "ES2020"` while `useDefineForClassFields` is on. ES2020 predates native class fields, so TypeScript downlevels field initializers into `Object.defineProperty` calls in the constructor.

`svelte-package` runs the TS transform before the Svelte compiler sees the file, so `dist/projection/node/create-projection-node.svelte.js` was emitted as:

```js
Object.defineProperty(this, "options", { value: $state({}) });
```

That is an illegal position for a rune, and the Svelte compiler rejects it in the consumer's build.

## Fix

Bump the target to `ES2022`, which supports class fields natively. TypeScript now emits:

```js
options = $state({});
```

ES2022 is already implied by the rest of the toolchain (Svelte 5, Vite 5+, Node 18+), so this doesn't narrow the supported runtimes in practice.

## Verification

From a clean checkout of this branch:

- `bun install && bun run package` succeeds
- `dist/projection/node/create-projection-node.svelte.js:117` is now `options = $state({});`
- Grepping all of `dist/` for `Object.defineProperty(this, ..., { value: $state/$derived ... })` returns no matches

## Follow-up

A new release is needed to get the corrected output onto npm — `0.2.0-next.0` is still broken for external consumers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s JavaScript compilation target to ES2022 for improved compatibility with modern language features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->