### PR TITLE
chore: add changeset for ES2022 target fix

### DIFF
--- a/.changeset/lucky-pugs-repeat.md
+++ b/.changeset/lucky-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+"motion-start": patch
+---
+
+Target `ES2022` in `tsconfig.json` so packaged output keeps native class fields instead of downlevelled `Object.defineProperty` assignments, which broke subclass field initialisation in consumers.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
 		// "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
 		/* Language and Environment */
-		"target": "ES2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+		"target": "ES2022" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
 		// "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
 		// "jsx": "preserve",                                /* Specify what JSX code is generated. */
 		// "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */


### PR DESCRIPTION
Adds the missing changeset for #57, which switched `tsconfig.json` to `target: ES2022` so packaged output keeps native class fields instead of downlevelled `Object.defineProperty` assignments.

Marked as a `patch` bump. Note the repo is currently in changesets pre mode (`next` tag), so this will land as a prerelease version.