### PR TITLE
fix(motion): scope component context and snapshot layout on every commit

### DIFF
--- a/.changeset/heavy-donkeys-shout.md
+++ b/.changeset/heavy-donkeys-shout.md
@@ -1,0 +1,36 @@
+---
+"motion-start": patch
+---
+
+Fix variant staggering and self-resizing `layout` animations.
+
+**Sibling motion components shared a context scope**
+
+`motion` components are hand-written component functions rather than compiled
+`.svelte` modules, so Svelte never opened a component context for them and
+`setContext` wrote into the nearest compiled ancestor's context map — which every
+sibling motion component shares. Contexts leaked sideways in mount order, so a
+variant parent adopted only its first child and each later child parented to its
+previous sibling, forming a chain instead of a fan-out.
+
+The visible symptom was that `staggerChildren` and `staggerDirection` did nothing:
+with one variant child per level there was nothing to stagger across, and every
+child received the same `delayChildren`. Anything relying on parent/child motion
+relationships between siblings was affected.
+
+**Plain `layout` animations snapped instead of animating**
+
+Framer-motion takes a pre-commit measurement on every render, so any prop that
+changes layout is covered. A Svelte effect only re-runs for the sources it reads,
+and the pre-pass tracked `layoutDependency` alone — so an element that resized
+itself (for example via `style`) never snapshotted and jumped straight to its new
+size.
+
+`layoutDependency` also absorbed the ambient `AnimatePresence` and `Reorder`
+version counters. Any element under a presence boundary therefore saw a constant
+dependency and suppressed its own snapshots entirely. Those counters are now
+tracked separately and add snapshot opportunities rather than replacing the
+user's own `layoutDependency`, restoring framer-motion's semantics.
+
+`layoutId` shared-layout animations, exit animations, and `Reorder` are
+unaffected.

--- a/src/lib/motion-start/motion/MotionScope.svelte
+++ b/src/lib/motion-start/motion/MotionScope.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
 /**
  * Opens a Svelte component context for a motion component.

--- a/src/lib/motion-start/motion/MotionScope.svelte
+++ b/src/lib/motion-start/motion/MotionScope.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+/**
+ * Opens a Svelte component context for a motion component.
+ *
+ * Motion components are hand-written component functions rather than compiled
+ * `.svelte` modules, so Svelte never opens a component context for them. Without
+ * one, `setContext` writes into the nearest compiled ancestor's context map,
+ * which every sibling motion component shares. Contexts then leak sideways in
+ * mount order: a variant parent adopts only its first child, and each later
+ * child parents to the previous sibling instead of the parent.
+ *
+ * Running the motion body inside this component's initialisation gives it the
+ * scope — and the effect ownership — a compiled component would have had.
+ */
+import { untrack } from 'svelte';
+
+let { run }: { run: () => void } = $props();
+
+// Initialising exactly once is the point: this component exists purely to open
+// a context scope, so the motion body must not re-run when props change.
+untrack(() => run)();
+</script>

--- a/src/lib/motion-start/motion/features/layout/MeasureLayout.svelte
+++ b/src/lib/motion-start/motion/features/layout/MeasureLayout.svelte
@@ -60,6 +60,13 @@ export const animateLayout = {
 
 	const reorderLayoutDependency = $derived(reorderContext?.orderVersion);
 
+	// Both contexts can be active at once (a reordered list inside an
+	// AnimatePresence), so combine them into a single comparable token rather
+	// than letting one mask updates from the other.
+	const ambientLayoutVersion = $derived(
+		`${String(reorderLayoutDependency)}:${String(presenceLayoutDependency)}`,
+	);
+
 	// custom can still serve as a local layout dependency when no explicit
 	// layoutDependency is provided.
 	const layoutGroup = $derived(
@@ -70,7 +77,7 @@ export const animateLayout = {
 <MeasureLayoutWithContext
 	{...props}
 	layoutDependency={props.layoutDependency ?? props.custom}
-	ambientLayoutVersion={reorderLayoutDependency ?? presenceLayoutDependency}
+	{ambientLayoutVersion}
 	measurePop={presenceMeasurePop}
 	{layoutGroup}
 	switchLayoutGroup={useSwitchLayoutGroupContext() ?? undefined}

--- a/src/lib/motion-start/motion/features/layout/MeasureLayout.svelte
+++ b/src/lib/motion-start/motion/features/layout/MeasureLayout.svelte
@@ -14,6 +14,13 @@ interface MeasureContextProps {
 	isPresent: boolean;
 	safeToRemove?: VoidFunction | null;
 	measurePop?: import('svelte/attachments').Attachment | null;
+	/**
+	 * Version counters contributed by an enclosing `AnimatePresence` or `Reorder`
+	 * group. These are separate from `layoutDependency` because they are ambient:
+	 * an element inherits them without opting in, so they must add snapshot
+	 * opportunities rather than replace the user's own dependency.
+	 */
+	ambientLayoutVersion?: unknown;
 }
 
 export interface MeasureProps extends MotionProps, MeasureContextProps {
@@ -62,9 +69,8 @@ export const animateLayout = {
 
 <MeasureLayoutWithContext
 	{...props}
-	layoutDependency={
-		props.layoutDependency ??
-		props.custom ?? reorderLayoutDependency ?? presenceLayoutDependency}
+	layoutDependency={props.layoutDependency ?? props.custom}
+	ambientLayoutVersion={reorderLayoutDependency ?? presenceLayoutDependency}
 	measurePop={presenceMeasurePop}
 	{layoutGroup}
 	switchLayoutGroup={useSwitchLayoutGroupContext() ?? undefined}

--- a/src/lib/motion-start/motion/features/layout/MeasureLayoutWithContext.svelte
+++ b/src/lib/motion-start/motion/features/layout/MeasureLayoutWithContext.svelte
@@ -93,7 +93,7 @@ watch.pre(
 		() => props.visualElement?.projection,
 		() => props.isPresent,
 	],
-	([], [, prevLayoutDependency, prevAmbientLayoutVersion, , , prevIsPresent]) => {
+	(_currentValues, [, prevLayoutDependency, prevAmbientLayoutVersion, , , prevIsPresent]) => {
 		const { layoutDependency, ambientLayoutVersion, visualElement, isPresent } = props;
 		const projection = visualElement?.projection;
 		const shouldSnapshot =

--- a/src/lib/motion-start/motion/features/layout/MeasureLayoutWithContext.svelte
+++ b/src/lib/motion-start/motion/features/layout/MeasureLayoutWithContext.svelte
@@ -28,6 +28,18 @@ const defaultScaleCorrectors = {
 const props: MeasureProps = $props();
 const safeToRemove = () => props.safeToRemove?.();
 
+/**
+ * Framer-motion runs `getSnapshotBeforeUpdate` on every render of the motion
+ * component, so any prop that can change layout — `style`, `class`, and so on —
+ * gets a pre-commit measurement for free. A Svelte effect only re-runs for the
+ * sources it actually reads, so tracking `layoutDependency` alone means a plain
+ * `layout` element that resizes itself (e.g. via `style`) never snapshots and
+ * therefore snaps instead of animating. Spreading `props` reads every prop and
+ * yields a fresh object identity per commit, which is the closest analogue to
+ * "this component re-rendered".
+ */
+const renderSnapshot = $derived.by(() => ({ ...props }));
+
 onMount(() => {
 	const { visualElement, layoutGroup, switchLayoutGroup, layoutId } = props;
 	const { projection } = visualElement;
@@ -73,11 +85,22 @@ let hasCompletedInitialPrepass = false;
 // Pre-commit snapshot phase. This is the Svelte analogue of
 // getSnapshotBeforeUpdate in framer-motion's MeasureLayout.
 watch.pre(
-	[() => props.layoutDependency, () => props.drag, () => props.visualElement?.projection, () => props.isPresent],
-	([], [prevLayoutDependency, , , prevIsPresent]) => {
-		const { layoutDependency, visualElement, isPresent } = props;
+	[
+		() => renderSnapshot,
+		() => props.layoutDependency,
+		() => props.ambientLayoutVersion,
+		() => props.drag,
+		() => props.visualElement?.projection,
+		() => props.isPresent,
+	],
+	([], [, prevLayoutDependency, prevAmbientLayoutVersion, , , prevIsPresent]) => {
+		const { layoutDependency, ambientLayoutVersion, visualElement, isPresent } = props;
 		const projection = visualElement?.projection;
-		const shouldSnapshot = props.drag || prevLayoutDependency !== layoutDependency || layoutDependency === undefined;
+		const shouldSnapshot =
+			props.drag ||
+			prevLayoutDependency !== layoutDependency ||
+			prevAmbientLayoutVersion !== ambientLayoutVersion ||
+			layoutDependency === undefined;
 
 		if (!projection) {
 			if (prevIsPresent !== isPresent && !isPresent) {

--- a/src/lib/motion-start/motion/index.svelte.ts
+++ b/src/lib/motion-start/motion/index.svelte.ts
@@ -22,6 +22,7 @@ import type { UseVisualState } from './utils/use-visual-state.svelte.js';
 import { motionComponentSymbol } from './utils/symbol.js';
 import { useVisualElement } from './utils/use-visual-element.svelte.js';
 import MeasureLayoutRenderer from './MeasureLayoutRenderer.svelte';
+import MotionScope from './MotionScope.svelte';
 
 export interface MotionComponentConfig<Instance, RenderState> {
 	preloadedFeatures?: FeatureBundle;
@@ -55,7 +56,7 @@ export const createRendererMotionComponent = <Props extends {}, Instance, Render
 }: MotionComponentConfig<Instance, RenderState>) => {
 	preloadedFeatures && loadFeatures(preloadedFeatures);
 
-	const MotionComponent: Component<MotionComponentProps<Props> & { ref?: Ref<Instance> }> = (anchor, props) => {
+	const renderMotionComponent: Component<MotionComponentProps<Props> & { ref?: Ref<Instance> }> = (anchor, props) => {
 		const motionConfig = $derived.by(useMotionConfigContext);
 		const configAndProps = $derived.by(() => {
 			const propsState = $state({
@@ -151,9 +152,9 @@ export const createRendererMotionComponent = <Props extends {}, Instance, Render
 		});
 
 		const measureProps = $derived.by(() => ({
-				...configAndProps,
-				visualElement: context.visualElement ?? undefined,
-			}));
+			...configAndProps,
+			visualElement: context.visualElement ?? undefined,
+		}));
 
 		// Let Svelte own the dynamic component branch so its lifecycle is torn
 		// down when layout/drag features disappear and recreated on replacement.
@@ -167,6 +168,25 @@ export const createRendererMotionComponent = <Props extends {}, Instance, Render
 		});
 
 		return rendererInstance;
+	};
+
+	/**
+	 * `MotionScope` is a compiled component, so initialising the motion body inside
+	 * it gives every motion component its own context scope. See `MotionScope.svelte`
+	 * for why that matters.
+	 */
+	const MotionComponent: Component<MotionComponentProps<Props> & { ref?: Ref<Instance> }> = (anchor, props) => {
+		const instance: { current: Record<string, any> | null } = { current: null };
+
+		MotionScope(anchor, {
+			run: () => {
+				instance.current = renderMotionComponent(anchor, props);
+			},
+		});
+
+		// `run` executes synchronously during MotionScope's initialisation, so the
+		// instance is always populated by the time we return it.
+		return instance.current!;
 	};
 
 	(MotionComponent as any)[motionComponentSymbol] = Component;


### PR DESCRIPTION
Two demos on the docs Examples page were visibly wrong. Both turned out to be library bugs rather than demo mistakes, and the first is systemic.

## Sibling motion components shared a context scope

`motion` components are hand-written component functions rather than compiled `.svelte` modules, so Svelte never opened a component context for them. `setContext` therefore wrote into the nearest compiled ancestor's context map — which every sibling motion component shares. Contexts leaked sideways in mount order: a variant parent adopted only its first child, and each later child parented to its *previous sibling*.

Instrumenting `animateChildren` on a five-item list showed `variantChildren.size` stuck at **1** at every level — a chain, not a fan-out. With one child per level there was nothing to stagger across, so `staggerChildren` did nothing and every item received the same `delayChildren`:

| child | before | after |
| --- | --- | --- |
| 0 | 321 ms | 315 ms |
| 1 | 321 ms | 465 ms |
| 2 | 321 ms | 615 ms |
| 3 | 321 ms | 765 ms |
| 4 | 321 ms | 915 ms |

(`delayChildren: 0.3`, `staggerChildren: 0.15` — the "after" column is exactly `0.3 + i × 0.15`.)

Initialising the motion body inside the new `MotionScope` component gives each motion component the scope a compiled component would have had. This was not stagger-specific — anything depending on parent/child motion relationships between siblings was affected.

## Plain `layout` animations snapped instead of animating

Two stacked causes:

**The pre-commit snapshot never re-ran.** Framer-motion runs `getSnapshotBeforeUpdate` on every render, so any prop that changes layout gets a measurement for free. A Svelte effect only re-runs for the sources it reads, and the pre-pass tracked `layoutDependency` alone — so an element resizing itself via `style` never snapshotted.

**`layoutDependency` was overloaded.** It also absorbed the ambient `AnimatePresence` and `Reorder` version counters. Any element under a presence boundary — including every page of these docs — saw a constant dependency and suppressed its own snapshots entirely. Instrumentation confirmed `shouldSnapshot: false` with `layoutDependency: 0` inherited from an enclosing `AnimatePresence`.

Those counters are now a separate `ambientLayoutVersion` that *adds* snapshot opportunities rather than replacing the user's dependency, restoring framer-motion's `layoutDependency` semantics.

Measured per-frame in a production build, a `layout` box springs 128 → 624 and settles at 622, and collapses symmetrically. Previously it jumped to its final width in a single frame with no transform ever applied.

## Verification

Measured in a real browser against a production build, not inferred from source:

- Stagger works in the isolated case and in the real `whileInView` demo (~80 ms apart for `staggerChildren: 0.08`).
- `layout` springs and settles in both directions.
- `layoutId` shared layout still springs smoothly with overshoot — unchanged.
- Exit animations still hold the node through its exit — unchanged.
- Page navigation still has zero layout shift — unchanged.
- 547 unit tests pass, 1 skipped.
- `sv check` reports 0 errors and 0 warnings.

## Release note

The repo is in changesets pre-release mode (tag `next`), so the patch changeset here cuts `0.2.0-next.2`.

*(Corrected: an earlier version of this description said it would fold into `0.2.0-next.1` and would carry the ES2022 packaging fix with it. #59 landed while this PR was open, so `0.2.0-next.1` is already published with that fix. This PR now carries only the two fixes above.)*

## Not addressed here

`AnimatePresence mode="wait"` still does not serialise — the incoming child mounts while the outgoing one is exiting. The `display: none` guard in `motion-outro.ts` depends on the outro calling `reserve()` before the intro reads `remaining()`, and Svelte builds the new keyed block first, so it usually reads `0`. Real `wait` semantics need the mount gated rather than the paint, which is a design change and does not belong in this patch. Being investigated separately on `investigate/animate-presence-wait-mode`.