### PR TITLE
fix: serialise AnimatePresence mode="wait"

### DIFF
--- a/.changeset/quiet-pots-repeat.md
+++ b/.changeset/quiet-pots-repeat.md
@@ -14,4 +14,8 @@ The incoming child is now taken out of flow imperatively at intro time and resto
 drops its node out of flow immediately, rather than lingering until Svelte's own outro timer
 elapses, which previously left a short window where both children were laid out.
 
+This applies to `SVGElement` children as well as `HTMLElement` ones. Children that are already
+out of flow (`position: absolute` / `fixed`) are left alone, since they cannot share layout with
+a sibling and hiding them would zero out the box read by projection and `onLayoutMeasure`.
+
 `mode="sync"` and `mode="popLayout"` are unaffected.

--- a/.changeset/quiet-pots-repeat.md
+++ b/.changeset/quiet-pots-repeat.md
@@ -1,0 +1,17 @@
+---
+'motion-start': patch
+---
+
+Fix `AnimatePresence mode="wait"` laying the incoming child out while the outgoing one is still exiting.
+
+The incoming child was kept out of flow by a `display: none` CSS transition delayed by
+`context.remaining()`, which reads a duration published by the outgoing child's outro. Svelte
+builds the incoming keyed block *before* tearing the outgoing one down, so the intro almost
+always read `0`, emitted no CSS at all, and both children shared the layout for the whole exit.
+
+The incoming child is now taken out of flow imperatively at intro time and restored once
+`waitForExit()` resolves, which removes the ordering dependency entirely. A finished exit also
+drops its node out of flow immediately, rather than lingering until Svelte's own outro timer
+elapses, which previously left a short window where both children were laid out.
+
+`mode="sync"` and `mode="popLayout"` are unaffected.

--- a/src/lib/motion-start/components/AnimatePresence/__tests__/WaitModeFixture.svelte
+++ b/src/lib/motion-start/components/AnimatePresence/__tests__/WaitModeFixture.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+import { motion } from '../../../index.js';
+import AnimatePresence from '../AnimatePresence.svelte';
+
+let { mode = 'wait' as 'sync' | 'wait' | 'popLayout' } = $props();
+
+let step = $state(0);
+</script>
+
+<button id="advance" onclick={() => (step += 1)}>advance</button>
+
+<div id="host">
+	<AnimatePresence {mode}>
+		{#key step}
+			<motion.div
+				class="page"
+				data-step={step}
+				initial={{ opacity: 0 }}
+				animate={{ opacity: 1 }}
+				exit={{ opacity: 0 }}
+				transition={{ duration: 0.05 }}
+			></motion.div>
+		{/key}
+	</AnimatePresence>
+</div>

--- a/src/lib/motion-start/components/AnimatePresence/__tests__/WaitModeFixture.svelte
+++ b/src/lib/motion-start/components/AnimatePresence/__tests__/WaitModeFixture.svelte
@@ -2,7 +2,7 @@
 import { motion } from '../../../index.js';
 import AnimatePresence from '../AnimatePresence.svelte';
 
-let { mode = 'wait' as 'sync' | 'wait' | 'popLayout' } = $props();
+let { mode = 'wait' as 'sync' | 'wait' | 'popLayout', variant = 'html' as 'html' | 'svg' | 'absolute' } = $props();
 
 let step = $state(0);
 </script>
@@ -12,14 +12,35 @@ let step = $state(0);
 <div id="host">
 	<AnimatePresence {mode}>
 		{#key step}
-			<motion.div
-				class="page"
-				data-step={step}
-				initial={{ opacity: 0 }}
-				animate={{ opacity: 1 }}
-				exit={{ opacity: 0 }}
-				transition={{ duration: 0.05 }}
-			></motion.div>
+			{#if variant === 'svg'}
+				<motion.svg
+					class="page"
+					data-step={step}
+					initial={{ opacity: 0 }}
+					animate={{ opacity: 1 }}
+					exit={{ opacity: 0 }}
+					transition={{ duration: 0.05 }}
+				></motion.svg>
+			{:else if variant === 'absolute'}
+				<motion.div
+					class="page"
+					data-step={step}
+					style={{ position: 'absolute' }}
+					initial={{ opacity: 0 }}
+					animate={{ opacity: 1 }}
+					exit={{ opacity: 0 }}
+					transition={{ duration: 0.05 }}
+				></motion.div>
+			{:else}
+				<motion.div
+					class="page"
+					data-step={step}
+					initial={{ opacity: 0 }}
+					animate={{ opacity: 1 }}
+					exit={{ opacity: 0 }}
+					transition={{ duration: 0.05 }}
+				></motion.div>
+			{/if}
 		{/key}
 	</AnimatePresence>
 </div>

--- a/src/lib/motion-start/components/AnimatePresence/__tests__/WaitModeFixture.svelte
+++ b/src/lib/motion-start/components/AnimatePresence/__tests__/WaitModeFixture.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
 import { motion } from '../../../index.js';
 import AnimatePresence from '../AnimatePresence.svelte';

--- a/src/lib/motion-start/components/AnimatePresence/__tests__/outro-lifecycle.svelte.spec.ts
+++ b/src/lib/motion-start/components/AnimatePresence/__tests__/outro-lifecycle.svelte.spec.ts
@@ -57,14 +57,18 @@ describe('AnimatePresence Svelte outro lifecycle', () => {
 		const target = document.querySelector('#exit-target') as HTMLElement;
 		const visualElement = visualElementStore.get(target);
 		const styles: string[] = [target.getAttribute('style') ?? ''];
-		const observer = new MutationObserver(() => {
+		const record = () => {
 			styles.push(target.getAttribute('style') ?? '');
-		});
+		};
+		const observer = new MutationObserver(record);
 		observer.observe(target, { attributes: true, attributeFilter: ['style'] });
 		click('#remove-exit');
 
 		expect(target.isConnected).toBe(true);
 		await waitFor(() => !target.isConnected);
+		// Records queued but not yet delivered would otherwise be dropped by
+		// `disconnect()`, losing the final committed style.
+		if (observer.takeRecords().length > 0) record();
 		observer.disconnect();
 
 		expect(target.style.opacity, `${styles.join('\n')}\nlatest=${String(visualElement?.latestValues.opacity)}`).toBe(

--- a/src/lib/motion-start/components/AnimatePresence/__tests__/wait-mode.svelte.spec.ts
+++ b/src/lib/motion-start/components/AnimatePresence/__tests__/wait-mode.svelte.spec.ts
@@ -1,0 +1,129 @@
+import { flushSync, mount, tick, unmount } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { nextFrame, waitFor } from '../../../test-utils/component-test-utils.js';
+import { MotionGlobalConfig } from '../../../utils/GlobalConfig.js';
+import WaitModeFixture from './WaitModeFixture.svelte';
+
+let instance: ReturnType<typeof mount> | undefined;
+const originalAnimate = Element.prototype.animate;
+
+beforeEach(() => {
+	Element.prototype.animate = ((_keyframes, options) => {
+		const duration = typeof options === 'number' ? options : Number(options?.duration ?? 0);
+		let cancelled = false;
+		const animation = {
+			currentTime: 0,
+			effect: {},
+			onfinish: null as (() => void) | null,
+			playState: 'running',
+			cancel() {
+				cancelled = true;
+				this.playState = 'idle';
+			},
+		};
+
+		setTimeout(() => {
+			if (cancelled) return;
+			animation.currentTime = duration;
+			animation.playState = 'finished';
+			animation.onfinish?.();
+		}, duration);
+
+		return animation as unknown as Animation;
+	}) as typeof Element.prototype.animate;
+});
+
+afterEach(async () => {
+	if (instance) await unmount(instance);
+	instance = undefined;
+	Element.prototype.animate = originalAnimate;
+	MotionGlobalConfig.skipAnimations = false;
+	document.body.innerHTML = '';
+});
+
+/**
+ * Records how many `.page` elements are laid out at once across the whole
+ * transition. `display: none` is treated as not laid out, since `mode="wait"`
+ * is allowed to keep a node in the tree as long as it takes up no space.
+ */
+function trackVisiblePages() {
+	const counts: number[] = [];
+
+	const sample = () => {
+		const pages = [...document.querySelectorAll('#host .page')] as HTMLElement[];
+		counts.push(pages.filter((page) => page.style.display !== 'none').length);
+	};
+
+	sample();
+	const observer = new MutationObserver(sample);
+	observer.observe(document.querySelector('#host') as HTMLElement, {
+		childList: true,
+		subtree: true,
+		attributes: true,
+		attributeFilter: ['style'],
+	});
+
+	return {
+		sample,
+		stop: () => {
+			observer.disconnect();
+			return counts;
+		},
+	};
+}
+
+describe('AnimatePresence mode="wait"', () => {
+	it('never lays out the incoming child while the outgoing one is still exiting', async () => {
+		instance = mount(WaitModeFixture, { target: document.body, props: { mode: 'wait' } });
+		flushSync();
+		await nextFrame();
+
+		const outgoing = document.querySelector('#host .page') as HTMLElement;
+		const tracker = trackVisiblePages();
+
+		(document.querySelector('#advance') as HTMLButtonElement).click();
+		flushSync();
+		tracker.sample();
+
+		await waitFor(() => !outgoing.isConnected);
+		await nextFrame();
+		tracker.sample();
+
+		const counts = tracker.stop();
+		expect(Math.max(...counts), `laid-out .page counts over time: ${counts.join(',')}`).toBe(1);
+	});
+
+	it('still ends with exactly the incoming child', async () => {
+		instance = mount(WaitModeFixture, { target: document.body, props: { mode: 'wait' } });
+		flushSync();
+		await nextFrame();
+
+		const outgoing = document.querySelector('#host .page') as HTMLElement;
+		(document.querySelector('#advance') as HTMLButtonElement).click();
+		flushSync();
+
+		await waitFor(() => !outgoing.isConnected);
+		await nextFrame();
+
+		const pages = [...document.querySelectorAll('#host .page')] as HTMLElement[];
+		expect(pages).toHaveLength(1);
+		expect(pages[0].dataset.step).toBe('1');
+		expect(pages[0].style.display).not.toBe('none');
+	});
+
+	it('does not hold back the first child, when nothing is exiting', async () => {
+		instance = mount(WaitModeFixture, { target: document.body, props: { mode: 'wait' } });
+		flushSync();
+
+		// The incoming node is hidden optimistically, because at intro time
+		// nothing knows yet whether an exit is about to start. With no outgoing
+		// child, `waitForExit()` resolves straight away, so the node must be back
+		// in flow by the time Svelte has settled -- well before the next paint.
+		await tick();
+		await tick();
+
+		const page = document.querySelector('#host .page') as HTMLElement;
+		expect(page.style.display).not.toBe('none');
+		expect(page.dataset.motionWaitDisplay).toBeUndefined();
+	});
+});

--- a/src/lib/motion-start/components/AnimatePresence/__tests__/wait-mode.svelte.spec.ts
+++ b/src/lib/motion-start/components/AnimatePresence/__tests__/wait-mode.svelte.spec.ts
@@ -126,4 +126,48 @@ describe('AnimatePresence mode="wait"', () => {
 		expect(page.style.display).not.toBe('none');
 		expect(page.dataset.motionWaitDisplay).toBeUndefined();
 	});
+
+	it('serialises SVG children the same way it serialises HTML children', async () => {
+		instance = mount(WaitModeFixture, { target: document.body, props: { mode: 'wait', variant: 'svg' } });
+		flushSync();
+		await nextFrame();
+
+		const outgoing = document.querySelector('#host .page') as SVGElement;
+		expect(outgoing).toBeInstanceOf(SVGElement);
+		const tracker = trackVisiblePages();
+
+		(document.querySelector('#advance') as HTMLButtonElement).click();
+		flushSync();
+		tracker.sample();
+
+		await waitFor(() => !outgoing.isConnected);
+		await nextFrame();
+		tracker.sample();
+
+		const counts = tracker.stop();
+		expect(Math.max(...counts), `laid-out .page counts over time: ${counts.join(',')}`).toBe(1);
+
+		const pages = [...document.querySelectorAll('#host .page')] as SVGElement[];
+		expect(pages).toHaveLength(1);
+		expect(pages[0].style.display).not.toBe('none');
+	});
+
+	it('leaves out-of-flow children measurable, since they cannot share layout', async () => {
+		instance = mount(WaitModeFixture, { target: document.body, props: { mode: 'wait', variant: 'absolute' } });
+		flushSync();
+
+		// An absolutely positioned child takes no part in flow, so hiding it
+		// would only zero out its box for projection and `onLayoutMeasure`.
+		const page = document.querySelector('#host .page') as HTMLElement;
+		expect(page.style.display).not.toBe('none');
+		expect(page.dataset.motionWaitDisplay).toBeUndefined();
+
+		(document.querySelector('#advance') as HTMLButtonElement).click();
+		flushSync();
+
+		const pages = [...document.querySelectorAll('#host .page')] as HTMLElement[];
+		for (const candidate of pages) {
+			expect(candidate.style.display).not.toBe('none');
+		}
+	});
 });

--- a/src/lib/motion-start/render/dom/motion-outro.ts
+++ b/src/lib/motion-start/render/dom/motion-outro.ts
@@ -287,14 +287,35 @@ function markProjectionWillUpdate(
 	return root;
 }
 
+/**
+ * `motion.svg` children render through the SVG config, so wait-mode layout
+ * control has to cover `SVGElement` as well as `HTMLElement`. Both expose
+ * `style` and `dataset`, which is all the hide/restore pair needs.
+ */
+function isWaitDisplayNode(motionNode: Element): motionNode is HTMLElement | SVGElement {
+	return motionNode instanceof HTMLElement || motionNode instanceof SVGElement;
+}
+
+/**
+ * Elements outside normal flow (`position: absolute` / `fixed`) cannot share
+ * layout with a sibling, so hiding them buys nothing and actively breaks
+ * measurement: a `display: none` node reports a zeroed box, which would feed a
+ * bogus snapshot into projection and `onLayoutMeasure`.
+ */
+function participatesInFlow(motionNode: HTMLElement | SVGElement) {
+	const { position } = getComputedStyle(motionNode);
+	return position !== 'absolute' && position !== 'fixed';
+}
+
 function hideFromLayout(motionNode: Element) {
-	if (!(motionNode instanceof HTMLElement) || motionNode.dataset.motionWaitDisplay !== undefined) return;
+	if (!isWaitDisplayNode(motionNode) || motionNode.dataset.motionWaitDisplay !== undefined) return;
+	if (!participatesInFlow(motionNode)) return;
 	motionNode.dataset.motionWaitDisplay = motionNode.style.display;
 	motionNode.style.display = 'none';
 }
 
 function restoreWaitDisplay(motionNode: Element) {
-	if (!(motionNode instanceof HTMLElement)) return;
+	if (!isWaitDisplayNode(motionNode)) return;
 	const previous = motionNode.dataset.motionWaitDisplay;
 	if (previous === undefined) return;
 	delete motionNode.dataset.motionWaitDisplay;
@@ -316,9 +337,10 @@ function restoreWaitDisplay(motionNode: Element) {
  * plain enter is restored in the same tick, before paint.
  */
 function deferLayoutUntilExitsComplete(motionNode: Element, context: MotionOutroContext) {
-	if (!(motionNode instanceof HTMLElement) || motionNode.dataset.motionWaitDisplay !== undefined) return;
+	if (!isWaitDisplayNode(motionNode) || motionNode.dataset.motionWaitDisplay !== undefined) return;
 
 	hideFromLayout(motionNode);
+	if (motionNode.dataset.motionWaitDisplay === undefined) return;
 
 	const reveal = () => restoreWaitDisplay(motionNode);
 

--- a/src/lib/motion-start/render/dom/motion-outro.ts
+++ b/src/lib/motion-start/render/dom/motion-outro.ts
@@ -1,3 +1,4 @@
+import { tick } from 'svelte';
 import type { TransitionConfig } from 'svelte/transition';
 import { getValueTransition } from '../../animation/utils/get-value-transition.js';
 import { applyPopLayout, removePopLayout } from '../../components/AnimatePresence/PopChild/pop-layout.js';
@@ -286,6 +287,46 @@ function markProjectionWillUpdate(
 	return root;
 }
 
+function hideFromLayout(motionNode: Element) {
+	if (!(motionNode instanceof HTMLElement) || motionNode.dataset.motionWaitDisplay !== undefined) return;
+	motionNode.dataset.motionWaitDisplay = motionNode.style.display;
+	motionNode.style.display = 'none';
+}
+
+function restoreWaitDisplay(motionNode: Element) {
+	if (!(motionNode instanceof HTMLElement)) return;
+	const previous = motionNode.dataset.motionWaitDisplay;
+	if (previous === undefined) return;
+	delete motionNode.dataset.motionWaitDisplay;
+	motionNode.style.display = previous;
+}
+
+/**
+ * `mode="wait"` must not lay the incoming child out until the outgoing one has
+ * finished exiting.
+ *
+ * This used to be attempted by delaying a `display: none` CSS transition by
+ * `context.remaining()`. That reads a duration the *outro* publishes through
+ * `reserve()`, but Svelte builds the incoming keyed block before tearing the
+ * outgoing one down, so the intro almost always read `0`, emitted no CSS at all,
+ * and both children were laid out at once.
+ *
+ * Hiding the node imperatively removes the ordering dependency: hide first, ask
+ * afterwards. `waitForExit()` resolves immediately when nothing is exiting, so a
+ * plain enter is restored in the same tick, before paint.
+ */
+function deferLayoutUntilExitsComplete(motionNode: Element, context: MotionOutroContext) {
+	if (!(motionNode instanceof HTMLElement) || motionNode.dataset.motionWaitDisplay !== undefined) return;
+
+	hideFromLayout(motionNode);
+
+	const reveal = () => restoreWaitDisplay(motionNode);
+
+	tick()
+		.then(() => context.waitForExit())
+		.then(reveal, reveal);
+}
+
 export function motionEnterIntro(
 	node: Element,
 	{ context, visualElement }: MotionOutroParams
@@ -315,22 +356,23 @@ export function motionEnterIntro(
 		motionNode.style.pointerEvents = motionNode.dataset.motionPrevPointerEvents;
 		delete motionNode.dataset.motionPrevPointerEvents;
 	}
+	// A reversed exit re-enters the same node, which `finish` may already have
+	// pulled out of flow.
+	restoreWaitDisplay(motionNode);
 	visualElement?.animationState?.setActive('exit', false);
 
-	return () => {
-		const delay = context?.mode === 'wait' ? context.remaining() : 0;
-		return {
-			delay,
-			duration: 0,
-			css: delay > 0 ? (t) => (t < 1 ? 'display: none' : '') : undefined,
-		};
-	};
+	if (context?.mode === 'wait') {
+		deferLayoutUntilExitsComplete(motionNode, context);
+	}
+
+	return () => ({ duration: 0 });
 }
 
 export function motionExitOutro(node: Element, { context, visualElement }: MotionOutroParams): TransitionConfig {
 	if (!context || !visualElement) return { duration: 0 };
 
 	const element = visualElement;
+	const outroContext = context;
 	const motionNode = getMotionNode(node, element);
 	const complete = context.begin();
 	let releasePopLayout: VoidFunction | undefined;
@@ -341,6 +383,15 @@ export function motionExitOutro(node: Element, { context, visualElement }: Motio
 		if (completed) return;
 		completed = true;
 		pendingExitFinish.delete(motionNode);
+		// The exit animation is done, but Svelte keeps the node mounted until its
+		// own outro timer elapses. In `wait` mode that trailing window would let
+		// the outgoing and incoming children share the layout, so drop the
+		// finished node out of flow immediately. `motionEnterIntro` restores it
+		// if the exit is reversed before removal.
+		if (outroContext.mode === 'wait') {
+			restoreWaitDisplay(motionNode);
+			hideFromLayout(motionNode);
+		}
 		complete(element.presenceContext?.id ?? 'outro', completedExit);
 	}
 


### PR DESCRIPTION
## The bug

`AnimatePresence mode="wait"` did not serialise. The incoming child mounted and took up layout
while the outgoing child was still exiting, so both were laid out at once for the entire exit.

## Root cause

The incoming child was meant to be held out of flow by `motionEnterIntro`:

```ts
const delay = context?.mode === 'wait' ? context.remaining() : 0;
return { delay, duration: 0, css: delay > 0 ? (t) => (t < 1 ? 'display: none' : '') : undefined };
```

`remaining()` is fed by `context.reserve(duration)`, which the *outgoing* child's outro calls.
But Svelte builds the incoming keyed block **before** tearing the outgoing one down, so the intro
almost always read `0` — which meant `css` was `undefined` and no guard was emitted at all.

A DOM dump taken mid-exit confirmed it: two `.page` nodes, both `display: block`, and **zero**
Svelte-generated `<style>` tags, i.e. the CSS transition never existed.

Interestingly the *animation* half of wait mode already worked — the incoming child correctly sat
at `opacity: 0` (via the existing `waitForExit()` gate in `use-visual-element.svelte.ts`). Only its
**layout participation** was wrong.

## The fix

Two changes in `render/dom/motion-outro.ts`:

1. **Hide first, ask afterwards.** `motionEnterIntro` now takes the incoming node out of flow
   imperatively and restores it once `waitForExit()` resolves. This removes the ordering dependency
   completely — we no longer need the outro to have run first. When nothing is exiting,
   `waitForExit()` resolves in the same tick, so a plain enter is restored before paint.

2. **Release a finished exit immediately.** `waitForExit()` resolves when the exit *animation*
   finishes, but Svelte keeps the node mounted until its own outro timer elapses — two different
   clocks. That trailing window still showed both children laid out (`1,1,1,1,2,2,1` in the new
   test). A finished exit now drops out of flow right away; `motionEnterIntro` restores it if the
   exit is reversed before removal.

`mode="sync"` and `mode="popLayout"` are untouched.

## Verification

**New tests** (`components/AnimatePresence/__tests__/wait-mode.svelte.spec.ts`), written RED first:

- never lays out the incoming child while the outgoing one is still exiting
- still ends with exactly the incoming child
- does not hold back the first child when nothing is exiting (no-flash regression guard)

Note the tests assert on **inline** `display`, not CSS keyframes — jsdom does not run CSS
animations, so the original keyframe-based approach was invisible to it. This is part of why the
bug survived.

**Real browser**, `/animate-presence-basics`, sampled every frame across a wait swap:

```
frame  0-19  wait-item-2:none:w=0   ,  wait-item-1:flex:w=200  (opacity 1 -> 0)
frame 28-47  wait-item-2:flex:w=200 (opacity 0 -> 1)
```

At no frame are both children laid out. Before the fix, both were laid out for the whole exit.

**Suite:** 550 unit tests pass (547 before + 3 new), 1 skipped. `sv check` reports 0 errors,
0 warnings.

## Notes

- `context.remaining()` is now unused by the intro. `reserve()`/`remaining()` are left on the outro
  context as-is to keep this change small; they can be retired separately.
- The docs site currently works around this with a single-cell grid on `#content`. That workaround
  should no longer be necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `AnimatePresence` `mode="wait"` so incoming and outgoing elements don’t share layout during exits.
  * Ensured the incoming element is restored promptly after `waitForExit()` completes, including for SVG and HTML children.
  * Updated outro/wait sequencing to avoid brief layout/visibility edge cases.
  * Confirmed `mode="sync"` and `mode="popLayout"` behavior remains unchanged.

* **Tests**
  * Added/expanded `mode="wait"` fixtures and specs to verify layout visibility and transition ordering, including out-of-flow positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->