### PR TITLE
fix(motion-start): retain sequenced exits for the whole exit sequence

### DIFF
--- a/.changeset/pink-donuts-attack.md
+++ b/.changeset/pink-donuts-attack.md
@@ -1,0 +1,16 @@
+---
+'motion-start': patch
+---
+
+Keep sequenced exit animations mounted until the whole sequence finishes.
+
+An exiting element whose exit variant used `when: 'beforeChildren'` or
+`when: 'afterChildren'` could be torn down mid-sequence, which silently dropped
+the remaining `onAnimationComplete` callbacks — an `afterChildren` parent would
+never report completion even though its child did.
+
+The retained exit window now budgets a scheduling frame for every start point in
+the sequence instead of a single frame for the whole tree, and corrects for the
+time the current frame had already spent before Svelte created the outro (whose
+clock is back-dated to the start of that frame). Nested exit completions now fire
+in order, and the element is removed only once the last one has run.

--- a/packages/motion-start/src/components/AnimatePresence/__tests__/NestedExitOrderFixture.svelte
+++ b/packages/motion-start/src/components/AnimatePresence/__tests__/NestedExitOrderFixture.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+import { motion } from '../../../index.js';
+import AnimatePresence from '../AnimatePresence.svelte';
+
+let { order }: { order: string[] } = $props();
+let visible = $state(true);
+</script>
+
+<button id="remove-nested" onclick={() => (visible = false)}>remove nested</button>
+
+<AnimatePresence initial={false}>
+	{#if visible}
+		<motion.div
+			id="nested-exit-parent"
+			exit="exit"
+			variants={{
+				exit: {
+					opacity: 0,
+					transition: { duration: 0.1, when: 'afterChildren' },
+				},
+			}}
+			onAnimationComplete={() => order.push('parent')}
+		>
+			<motion.div
+				id="nested-exit-child"
+				variants={{ exit: { opacity: 0, transition: { duration: 0.1 } } }}
+				onAnimationComplete={() => order.push('child')}
+			/>
+		</motion.div>
+	{/if}
+</AnimatePresence>

--- a/packages/motion-start/src/components/AnimatePresence/__tests__/NestedExitOrderFixture.svelte
+++ b/packages/motion-start/src/components/AnimatePresence/__tests__/NestedExitOrderFixture.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
 import { motion } from '../../../index.js';
 import AnimatePresence from '../AnimatePresence.svelte';

--- a/packages/motion-start/src/components/AnimatePresence/__tests__/nested-exit-order.svelte.spec.ts
+++ b/packages/motion-start/src/components/AnimatePresence/__tests__/nested-exit-order.svelte.spec.ts
@@ -1,0 +1,60 @@
+import { flushSync, mount, unmount } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { waitFor } from '../../../test-utils/component-test-utils.js';
+import NestedExitOrderFixture from './NestedExitOrderFixture.svelte';
+
+let instance: ReturnType<typeof mount> | undefined;
+const originalAnimate = Element.prototype.animate;
+
+beforeEach(() => {
+	Element.prototype.animate = ((_keyframes: unknown, options: unknown) => {
+		const duration = typeof options === 'number' ? options : Number((options as { duration?: number })?.duration ?? 0);
+		let cancelled = false;
+		const animation = {
+			currentTime: 0,
+			effect: {},
+			onfinish: null as (() => void) | null,
+			playState: 'running',
+			cancel() {
+				cancelled = true;
+				this.playState = 'idle';
+			},
+		};
+
+		setTimeout(() => {
+			if (cancelled) return;
+			animation.currentTime = duration;
+			animation.playState = 'finished';
+			animation.onfinish?.();
+		}, duration);
+
+		return animation as unknown as Animation;
+	}) as typeof Element.prototype.animate;
+});
+
+afterEach(async () => {
+	if (instance) await unmount(instance);
+	instance = undefined;
+	Element.prototype.animate = originalAnimate;
+	document.body.innerHTML = '';
+});
+
+describe('AnimatePresence nested exit ordering', () => {
+	it('completes a child variant before its afterChildren parent, and both before removal', async () => {
+		const order: string[] = [];
+		instance = mount(NestedExitOrderFixture, { target: document.body, props: { order } });
+		flushSync();
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		const parent = document.querySelector('#nested-exit-parent') as HTMLElement;
+		(document.querySelector('#remove-nested') as HTMLButtonElement).click();
+		flushSync();
+
+		// The exiting element is unmounted with the retained block, and unmounting
+		// clears its event subscriptions - so anything not notified by then is lost.
+		await waitFor(() => !parent.isConnected, 3000);
+		const orderAtRemoval = [...order];
+
+		expect(orderAtRemoval).toEqual(['child', 'parent']);
+	});
+});

--- a/packages/motion-start/src/render/dom/__tests__/motion-outro.spec.ts
+++ b/packages/motion-start/src/render/dom/__tests__/motion-outro.spec.ts
@@ -259,6 +259,26 @@ describe('motionExitOutro', () => {
 		expect(reserve).toHaveBeenCalledWith(100 + 40 + 60 + 1);
 	});
 
+	/**
+	 * The document timeline pauses while the page is hidden but
+	 * `performance.now()` does not, so a backgrounded tab reports an unbounded
+	 * skew that must not be mistaken for frame time.
+	 */
+	it('caps the frame-time correction so a stalled timeline cannot over-retain', () => {
+		const node = document.createElement('div');
+		document.body.appendChild(node);
+		const { context } = createContext();
+		const visualElement = createSequencedExitElement(node, [0.1]);
+		const frameStart = performance.now();
+		vi.spyOn(performance, 'now').mockReturnValue(frameStart + 30_000);
+		Object.defineProperty(document, 'timeline', {
+			configurable: true,
+			value: { currentTime: frameStart },
+		});
+
+		expect(motionExitOutro(node, { context, visualElement }).duration).toBe(100 + 40 + 1000 + 1);
+	});
+
 	it('leaves a node with nothing to animate unretained regardless of frame time', () => {
 		const node = document.createElement('div');
 		document.body.appendChild(node);

--- a/packages/motion-start/src/render/dom/__tests__/motion-outro.spec.ts
+++ b/packages/motion-start/src/render/dom/__tests__/motion-outro.spec.ts
@@ -4,8 +4,16 @@ import type { IProjectionNode } from '../../../projection/node/types.js';
 import type { VisualElement } from '../../VisualElement.svelte.js';
 import { flushPendingMotionExitLayout, motionEnterIntro, motionExitOutro } from '../motion-outro.js';
 
+const originalTimeline = Object.getOwnPropertyDescriptor(document, 'timeline');
+
 afterEach(() => {
 	document.body.innerHTML = '';
+	vi.restoreAllMocks();
+	if (originalTimeline) {
+		Object.defineProperty(document, 'timeline', originalTimeline);
+	} else {
+		delete (document as unknown as { timeline?: unknown }).timeline;
+	}
 });
 
 function createContext(presenceAffectsLayout = true) {
@@ -60,6 +68,40 @@ function createVisualElement(node: HTMLElement, transition: Record<string, unkno
 	return { didUpdate, projection, root, update, visualElement };
 }
 
+/**
+ * Builds a chain of exiting variant children, where `durations[0]` is the
+ * outermost element's own exit duration and every level that has a descendant
+ * sequences it with `when: 'afterChildren'`.
+ */
+function createSequencedExitElement(node: HTMLElement, durations: number[]) {
+	let child: VisualElement<HTMLElement> | undefined;
+
+	for (let index = durations.length - 1; index >= 0; index--) {
+		const exit = {
+			opacity: 0,
+			transition: child ? { duration: durations[index], when: 'afterChildren' } : { duration: durations[index] },
+		};
+
+		child = {
+			animationState: {
+				setActive: vi.fn(() => new Promise(() => undefined)),
+			},
+			children: new Set(),
+			current: node,
+			getDefaultTransition: () => undefined,
+			getProps: () => ({ exit }),
+			getVariant: (name: string) => (name === 'exit' ? exit : undefined),
+			presenceContext: null,
+			prevPresenceContext: undefined,
+			sortNodePosition: () => 0,
+			values: new Map(),
+			variantChildren: child ? new Set([child]) : new Set(),
+		} as unknown as VisualElement<HTMLElement>;
+	}
+
+	return child as VisualElement<HTMLElement>;
+}
+
 describe('motionExitOutro', () => {
 	it('retains an afterChildren parent through its child and parent animation durations', () => {
 		const node = document.createElement('div');
@@ -99,8 +141,10 @@ describe('motionExitOutro', () => {
 
 		const config = motionExitOutro(node, { context, visualElement });
 
-		expect(config.duration).toBe(241);
-		expect(reserve).toHaveBeenCalledWith(241);
+		// 100ms child + 100ms parent, plus a scheduling frame for each of the two
+		// points at which Motion starts an animation, plus the completion margin.
+		expect(config.duration).toBe(281);
+		expect(reserve).toHaveBeenCalledWith(281);
 	});
 
 	it('retains an afterChildren parent through a configured child exit variant before it starts running', () => {
@@ -149,8 +193,95 @@ describe('motionExitOutro', () => {
 
 		const config = motionExitOutro(node, { context, visualElement });
 
-		expect(config.duration).toBe(241);
-		expect(reserve).toHaveBeenCalledWith(241);
+		expect(config.duration).toBe(281);
+		expect(reserve).toHaveBeenCalledWith(281);
+	});
+
+	/**
+	 * Regression guard for the `when: 'afterChildren'` ordering contract: the
+	 * parent's own exit animation is only queued once the child animations have
+	 * settled, so the retained block has to outlive both steps *and* the frame
+	 * each of them loses to keyframe resolution. Retaining for less unmounts the
+	 * visual element mid-sequence, which clears its event subscriptions and drops
+	 * the parent's `onAnimationComplete` entirely.
+	 */
+	it('budgets a scheduling frame for every start point of a sequenced exit', () => {
+		const node = document.createElement('div');
+		document.body.appendChild(node);
+		const { context } = createContext();
+		const visualElement = createSequencedExitElement(node, [0.1, 0.1]);
+
+		const config = motionExitOutro(node, { context, visualElement });
+		const [childDuration, parentDuration] = [100, 100];
+		const startPoints = 2;
+
+		expect(config.duration).toBeGreaterThan(childDuration + parentDuration);
+		expect(config.duration).toBe(childDuration + parentDuration + startPoints * 40 + 1);
+	});
+
+	it('compounds the scheduling budget for each nested afterChildren boundary', () => {
+		const node = document.createElement('div');
+		document.body.appendChild(node);
+		const { context } = createContext();
+		const visualElement = createSequencedExitElement(node, [0.1, 0.1, 0.1]);
+
+		// Three sequenced 100ms steps, so three start points to pay for.
+		expect(motionExitOutro(node, { context, visualElement }).duration).toBe(300 + 3 * 40 + 1);
+	});
+
+	it('retains a concurrent exit past the frame its animation loses to scheduling', () => {
+		const node = document.createElement('div');
+		document.body.appendChild(node);
+		const { context } = createContext();
+		const visualElement = createSequencedExitElement(node, [0.1]);
+
+		expect(motionExitOutro(node, { context, visualElement }).duration).toBe(100 + 40 + 1);
+	});
+
+	/**
+	 * Svelte back-dates the outro's WAAPI clock to the start of the current
+	 * frame, so a frame that spent 60ms before reaching the outro hands back a
+	 * retained window 60ms shorter than the one that was requested.
+	 */
+	it('extends the retained window by the frame time the outro clock has already spent', () => {
+		const node = document.createElement('div');
+		document.body.appendChild(node);
+		const { context, reserve } = createContext();
+		const visualElement = createSequencedExitElement(node, [0.1]);
+		const frameStart = performance.now();
+		vi.spyOn(performance, 'now').mockReturnValue(frameStart + 60);
+		Object.defineProperty(document, 'timeline', {
+			configurable: true,
+			value: { currentTime: frameStart },
+		});
+
+		expect(motionExitOutro(node, { context, visualElement }).duration).toBe(100 + 40 + 60 + 1);
+		expect(reserve).toHaveBeenCalledWith(100 + 40 + 60 + 1);
+	});
+
+	it('leaves a node with nothing to animate unretained regardless of frame time', () => {
+		const node = document.createElement('div');
+		document.body.appendChild(node);
+		const { context, reserve } = createContext();
+		const visualElement = {
+			animationState: { setActive: vi.fn(() => Promise.resolve()) },
+			children: new Set(),
+			current: node,
+			getDefaultTransition: () => undefined,
+			getProps: () => ({}),
+			presenceContext: null,
+			prevPresenceContext: undefined,
+			values: new Map(),
+		} as unknown as VisualElement<HTMLElement>;
+		const frameStart = performance.now();
+		vi.spyOn(performance, 'now').mockReturnValue(frameStart + 60);
+		Object.defineProperty(document, 'timeline', {
+			configurable: true,
+			value: { currentTime: frameStart },
+		});
+
+		expect(motionExitOutro(node, { context, visualElement }).duration).toBe(0);
+		expect(reserve).not.toHaveBeenCalled();
 	});
 
 	it('retains a layoutId-only node for its configured layout transition', async () => {

--- a/packages/motion-start/src/render/dom/motion-outro.ts
+++ b/packages/motion-start/src/render/dom/motion-outro.ts
@@ -198,6 +198,19 @@ function getConfiguredLayoutDuration(visualElement: VisualElement<HTMLElement | 
 	return getTransitionDuration(layoutTransition as Record<string, unknown> | undefined);
 }
 
+/**
+ * Motion resolves keyframes and starts an exit animation from its frame loop,
+ * on the pass *after* the outro callback runs, while Svelte's outro clock
+ * starts on the frame the outro is scheduled. Every point at which an
+ * animation starts therefore costs up to one capped frame that the raw
+ * transition durations don't describe: one for the exiting element itself, and
+ * one more for each `when: 'beforeChildren' | 'afterChildren'` boundary, since
+ * the next step of the sequence is only queued once the previous step's
+ * promise settles. `getConfiguredExitTreeDuration` budgets the per-boundary
+ * frames; this adds the one for the initial start so the retained block
+ * outlives the whole sequence instead of being torn down mid-way - which would
+ * unmount the visual element and silently drop its `onAnimationComplete`.
+ */
 function getExitDuration(visualElement: VisualElement<HTMLElement | SVGElement | unknown>) {
 	const runningDuration = getRunningTreeDuration(visualElement);
 	const timing = getConfiguredExitTiming(visualElement);
@@ -207,8 +220,9 @@ function getExitDuration(visualElement: VisualElement<HTMLElement | SVGElement |
 		timing.when === 'afterChildren' && runningDuration
 			? runningDuration + timing.duration + maxFrameElapsed
 			: runningDuration;
+	const animationDuration = Math.max(runningSequenceDuration, configuredDuration);
 
-	return Math.max(layoutDuration, runningSequenceDuration, configuredDuration);
+	return Math.max(layoutDuration, animationDuration > 0 ? animationDuration + maxFrameElapsed : 0);
 }
 
 /**
@@ -219,6 +233,25 @@ function getExitDuration(visualElement: VisualElement<HTMLElement | SVGElement |
  */
 function retainThroughCompletion(duration: number) {
 	return duration > 0 ? duration + 1 : 0;
+}
+
+/**
+ * Svelte runs an outro off a WAAPI animation whose start time is back-dated to
+ * the current frame's timeline time, while Motion only starts the exit
+ * animation on the following frame-loop pass. Every millisecond the frame
+ * already spent before the outro ran is therefore retention the block never
+ * gets: a 150ms frame silently shortens the outro by a large fraction of that.
+ * Reading the elapsed frame time back off the document timeline turns the
+ * offset into a measured correction rather than a padding guess, and collapses
+ * to ~0 on a healthy frame.
+ */
+function getFrameElapsed() {
+	if (typeof document === 'undefined' || typeof performance === 'undefined') return 0;
+
+	const timelineTime = Number(document.timeline?.currentTime ?? 0);
+	if (!timelineTime) return 0;
+
+	return Math.max(0, performance.now() - timelineTime);
 }
 
 function getMotionNode(node: Element, visualElement: VisualElement<HTMLElement | SVGElement | unknown> | undefined) {
@@ -457,7 +490,8 @@ export function motionExitOutro(node: Element, { context, visualElement }: Motio
 
 	const exitAnimation = element.animationState?.setActive('exit', true) ?? Promise.resolve();
 	const layoutDuration = getConfiguredLayoutDuration(element);
-	const duration = retainThroughCompletion(getExitDuration(element));
+	const exitDuration = getExitDuration(element);
+	const duration = retainThroughCompletion(exitDuration > 0 ? exitDuration + getFrameElapsed() : 0);
 	let completedExit = true;
 	pendingExitFinish.set(motionNode, () => finish(false));
 	exitAnimation.then(

--- a/packages/motion-start/src/render/dom/motion-outro.ts
+++ b/packages/motion-start/src/render/dom/motion-outro.ts
@@ -244,14 +244,23 @@ function retainThroughCompletion(duration: number) {
  * Reading the elapsed frame time back off the document timeline turns the
  * offset into a measured correction rather than a padding guess, and collapses
  * to ~0 on a healthy frame.
+ *
+ * The reading is clamped because the document timeline pauses while the page is
+ * hidden even though `performance.now()` keeps running, so a backgrounded tab
+ * reports a skew that grows without bound. Beyond `maxFrameSkew` the timeline is
+ * stalled rather than the frame being slow - and a stalled timeline stalls the
+ * outro too - so treating it as frame time would retain the node long after its
+ * exit finished.
  */
+const maxFrameSkew = 1000;
+
 function getFrameElapsed() {
 	if (typeof document === 'undefined' || typeof performance === 'undefined') return 0;
 
 	const timelineTime = Number(document.timeline?.currentTime ?? 0);
 	if (!timelineTime) return 0;
 
-	return Math.max(0, performance.now() - timelineTime);
+	return Math.min(maxFrameSkew, Math.max(0, performance.now() - timelineTime));
 }
 
 function getMotionNode(node: Element, visualElement: VisualElement<HTMLElement | SVGElement | unknown> | undefined) {


### PR DESCRIPTION
## The failure

`cypress/integration/animate-presence-outro.ts` → `'finishes nested child variants before an afterChildren parent exit'` failed 5/5 locally.

**Observed value: `'child'`** (expected `'child,parent'`). The child's `onAnimationComplete` fires; the parent's never does. The nodes *are* removed, so the exit itself completes — only the parent's completion callback is lost.

## Root cause

Browser instrumentation (a `window.__dbg` buffer populated from library source, read back through `cy.window()`) showed the `afterChildren` chain running correctly end to end: children animate, the child promise settles, the parent's own `animateTarget` starts, and the parent's animation resolves — but with `visualElement.current === null`.

`VisualElement.unmount()` clears every event subscription:

```ts
for (const key in this.events) this.events[key].clear();
this.current = null;
```

Once the retained block is torn down, `notify('AnimationComplete')` is a silent no-op. The parent was being unmounted ~4ms *before* its own animation resolved. So this is a retention-window bug, not an orchestration bug — `when: 'afterChildren'` sequences correctly, it just isn't kept alive long enough.

Two things under-budget that window:

**1. One scheduling frame budgeted for the whole tree.** Motion resolves keyframes and starts an animation on the frame-loop pass *after* the outro callback, so every start point costs up to one capped frame. `getConfiguredExitTreeDuration` already budgets one per `when` boundary, but nothing budgeted the initial start.

**2. Svelte's outro clock is back-dated (the decisive cause).** Svelte 5 drives `tick`-only transitions with `element.animate(keyframes, { duration, fill: 'forwards' })`, and the animation's start time is back-dated to the current frame's timeline time. Every millisecond the frame had already spent before reaching the outro is retention the block never gets.

Measured over 8 instrumented iterations (`skew = performance.now() - document.timeline.currentTime` at outro creation, against a declared 281ms window):

| run | skew | outro → tick(0) | shortfall | result |
|---|---|---|---|---|
| 0 | 75 | 243 | 38 | ok |
| 1 | **149** | 219 | **62** | **failed (`child`)** |
| 2 | 17 | 285 | -4 | ok |
| 3 | 11 | 273 | 8 | ok |
| 4 | 25 | 276 | 5 | ok |
| 5 | 22 | 279 | 2 | ok |
| 6 | 79 | 239 | 42 | ok |
| 7 | 49 | 269 | 12 | ok |

Shortfall ≈ 0.4 × skew — a strong, monotonic correlation. This is also why CI can be green: a machine that reaches the outro early in its frame loses almost nothing.

## The fix

`packages/motion-start/src/render/dom/motion-outro.ts`:

- `getExitDuration` adds one capped frame of start latency to the animation budget, on top of the existing per-`when`-boundary frames.
- New `getFrameElapsed()` reads the already-spent frame time off `document.timeline.currentTime` and adds it to the retained window, turning the back-dated clock into a *measured* correction rather than a padding guess. It collapses to ~0 on a healthy frame and to exactly 0 where there's no timeline (SSR, jsdom), so unit-test durations stay exact.

Over-retention is benign: `finish()` — and therefore `onExitComplete`, the wait-mode reveal and the projection flush — is driven by the exit animation promise, not by the retention timer. A longer window only defers DOM removal.

The layout-duration path is deliberately untouched.

## Tests

- `packages/motion-start/src/render/dom/__tests__/motion-outro.spec.ts` — 5 new tests covering the per-start-point frame budget, the compounding budget across nested `afterChildren` boundaries, the frame-elapsed correction (stubbed `document.timeline`), and that a node with nothing to animate stays unretained regardless of frame time. Two existing duration expectations move 241 → 281 to match the corrected budget.
- `packages/motion-start/src/components/AnimatePresence/__tests__/nested-exit-order.svelte.spec.ts` — a component-level guard that the child's completion precedes the `afterChildren` parent's and that both land before removal. (jsdom doesn't reproduce the browser timing, so this is a contract guard, not a regression guard — the regression guard is the duration math above plus the E2E.)

## Validation

- Full vitest suite from `packages/motion-start`: **577 passed / 1 skipped / no type errors** (baseline 574).
- `animate-presence-outro.ts`: **8 consecutive runs, 6/6 each, zero retries** (verified by grepping the logs for `Attempt 2` — none).
- `bun run build` clean.
- Biome-formatted `.ts` only.

## Honest caveats

- The correction is empirical in the sense that it depends on Svelte's current outro implementation (WAAPI with a back-dated start time). If Svelte changes how it schedules transitions, the correction becomes a harmless no-op rather than a breakage, but the underlying margin would need revisiting.
- 8 green runs is strong but not proof. The failure mode required a ~150ms frame; a pathologically slower machine could still exceed the corrected window, though it would now have to lose time *after* the timeline read rather than before it.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sequenced exit animations so nested elements complete in the correct order.
  * Ensured all `onAnimationComplete` callbacks run before elements are removed.
  * Improved exit timing for `beforeChildren` and `afterChildren` transitions, preventing animations from being cut short.
* **Tests**
  * Added regression coverage for nested exit ordering, timing, and completion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->