### PR TITLE
fix(reorder): stop Reorder.Item discarding a caller's layoutDependency

### DIFF
--- a/.changeset/proud-moons-repeat.md
+++ b/.changeset/proud-moons-repeat.md
@@ -1,0 +1,18 @@
+---
+'motion-start': patch
+---
+
+Stop `Reorder.Item` discarding a caller-supplied `layoutDependency`.
+
+`Reorder.Item` set `layoutDependency={orderVersion}` *after* the `{...props}` spread, so any
+`layoutDependency` passed by the caller was silently overwritten by the group's internal order
+version. That is also redundant: `MeasureLayout` already folds the group's `orderVersion` into an
+*ambient* layout version, which adds snapshot opportunities rather than replacing the user's own
+dependency. A board that moves items between groups needs its own `layoutDependency` to reach the
+item, so the prop is now left alone.
+
+Also adds regression coverage for a shared `layoutId` element that unmounts from one parent and
+mounts into another in the same update: unit tests for the projection handover in both commit
+orders (outgoing destroyed first, incoming created first), and a Cypress spec that samples the
+element's position per animation frame to assert it animates between the two parents instead of
+teleporting.

--- a/cypress/integration/layout-shared-cross-parent.ts
+++ b/cypress/integration/layout-shared-cross-parent.ts
@@ -1,0 +1,70 @@
+/**
+ * A `layoutId` element that unmounts from one parent and mounts into another in
+ * the same update should animate between the two positions rather than
+ * teleporting. Sampling per animation frame is the only way to tell a fast
+ * animation apart from no animation at all.
+ *
+ * The click has to be dispatched from inside the sampling task rather than as a
+ * separate Cypress command: on a loaded machine the gap between two commands can
+ * exceed the animation's duration, so the sampler would only ever see the
+ * resting position and a genuine animation would look like a teleport.
+ */
+const variants = ['plain', 'xy', 'reorder'] as const;
+
+const MAX_FRAMES = 120;
+const SETTLED_FRAMES = 8;
+
+function measureLeft(win: Window) {
+	const el = win.document.getElementById('box');
+	return el ? Math.round(el.getBoundingClientRect().left) : null;
+}
+
+function clickAndSample(win: Window): Promise<number[]> {
+	return new Promise((resolve) => {
+		const samples: number[] = [];
+		let settled = 0;
+
+		const tick = () => {
+			const left = measureLeft(win);
+			if (left !== null) {
+				settled = left === samples[samples.length - 1] ? settled + 1 : 0;
+				samples.push(left);
+			}
+
+			if (samples.length >= MAX_FRAMES || settled >= SETTLED_FRAMES) {
+				resolve(samples);
+			} else {
+				win.requestAnimationFrame(tick);
+			}
+		};
+
+		win.document.getElementById('move')?.click();
+		win.requestAnimationFrame(tick);
+	});
+}
+
+describe('Shared layoutId across parents', () => {
+	for (const variant of variants) {
+		it(`animates a ${variant} element between two parents`, () => {
+			cy.visit(`?test=layout-shared-cross-parent&variant=${variant}`);
+			cy.get('html').should('have.attr', 'data-fixture-ready', 'layout-shared-cross-parent');
+			cy.get('#box').should('exist');
+
+			cy.window()
+				.then((win) => {
+					const start = measureLeft(win) as number;
+					return clickAndSample(win).then((samples) => ({ start, samples }));
+				})
+				.then(({ start, samples }) => {
+					const end = samples[samples.length - 1];
+					const detail = `start=${start} samples=${JSON.stringify(samples)}`;
+
+					expect(end, `element reaches the other column: ${detail}`).to.be.greaterThan(start + 100);
+
+					const distinct = new Set(samples.filter((left) => left > start && left < end));
+
+					expect(distinct.size, `expected intermediate frames, got ${detail}`).to.be.greaterThan(2);
+				});
+		});
+	}
+});

--- a/packages/motion-start/src/components/Reorder/Item.svelte
+++ b/packages/motion-start/src/components/Reorder/Item.svelte
@@ -87,11 +87,18 @@ function useDefaultMotionValue(value: any, defaultValue = 0) {
 	);
 
 	const axis = $derived(context?.axis);
-	const orderVersion = $derived(context?.orderVersion);
 	const registerItem = $derived(context?.registerItem);
 	const updateOrder = $derived(context?.updateOrder);
 </script>
 
+<!--
+	`layoutDependency` is deliberately not set here. The group's `orderVersion`
+	already reaches every item as an *ambient* layout version (see
+	`MeasureLayout`), which adds snapshot opportunities without replacing the
+	user's own dependency. Setting it as a prop here would land after `{...props}`
+	and silently discard a `layoutDependency` the caller passed in — which a board
+	that moves items between groups needs in order to animate.
+-->
 <ReorderItem
 	drag={dragProp ?? axis}
 	{...props}
@@ -122,7 +129,6 @@ function useDefaultMotionValue(value: any, defaultValue = 0) {
 	}}
 	ref={externalRef}
 	{layout}
-	layoutDependency={orderVersion}
 	ignoreStrict
 >
 	{invariant(

--- a/packages/motion-start/src/projection/node/__tests__/shared-remount.svelte.spec.ts
+++ b/packages/motion-start/src/projection/node/__tests__/shared-remount.svelte.spec.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test, vi } from 'vitest';
+import { nextFrame } from '../../../test-utils/component-test-utils.js';
+import type { Box } from '../../geometry/types.js';
+import { createTestNode } from './TestProjectionNode.svelte.js';
+
+function createInstance(id: string, min: number, max: number) {
+	const instance = {
+		id,
+		resetTransform: vi.fn(),
+		box: {
+			x: { min, max },
+			y: { min: 0, max: 50 },
+		} as Box,
+	};
+
+	const visualElement = {
+		current: instance,
+		mount: vi.fn(),
+		notify: vi.fn(),
+		render: vi.fn(),
+		scheduleRender: vi.fn(),
+		setStaticValue: vi.fn(),
+		getProps: () => ({}),
+		getDefaultTransition: () => undefined,
+		shouldReduceMotion: false,
+		latestValues: {},
+		measureViewportBox: () => ({
+			x: { ...instance.box.x },
+			y: { ...instance.box.y },
+		}),
+	};
+
+	return { instance, visualElement };
+}
+
+function createNode(parent: any, min: number, max: number, options: Record<string, unknown> = {}) {
+	const { instance, visualElement } = createInstance(`${min}-${max}`, min, max);
+	const node = createTestNode(parent, {
+		// The animation path needs a full VisualElement; these tests only care
+		// about the layout handover, so measurement is all that's wired up.
+		animate: false,
+		visualElement: visualElement as any,
+		...options,
+	});
+	node.mount(instance);
+	return node;
+}
+
+/**
+ * A `layoutId` element that unmounts from one parent and mounts into another in
+ * the same update - the "magic motion" handover. Svelte, unlike React, does not
+ * rerender the outgoing element before the incoming one mounts, and the two
+ * branches can commit in either order depending on where they sit in the tree.
+ * Both orders have to leave the incoming node with a snapshot of where the
+ * outgoing one was, otherwise the element teleports with `transform: none`.
+ */
+describe('shared layoutId across parents', () => {
+	async function setup(layoutId: string) {
+		const parentA = createNode(undefined, 0, 100);
+		const parentB = createNode(undefined, 200, 300);
+		const outgoing = createNode(parentA, 0, 50, { layoutId, layout: true });
+
+		parentA.willUpdate();
+		parentB.willUpdate();
+		outgoing.willUpdate();
+		outgoing.root.didUpdate();
+		await nextFrame();
+
+		expect(outgoing.layout?.layoutBox.x).toEqual({ min: 0, max: 50 });
+
+		return { parentB, outgoing };
+	}
+
+	test('hands the layout over when the outgoing branch is destroyed first', async () => {
+		const layoutId = 'card-destroy-first';
+		const { parentB, outgoing } = await setup(layoutId);
+
+		outgoing.unmount();
+
+		const incoming = createNode(parentB, 200, 250, { layoutId, layout: true });
+
+		expect(incoming.resumeFrom).toBe(outgoing);
+		expect(incoming.snapshot?.layoutBox.x).toEqual({ min: 0, max: 50 });
+	});
+
+	test('hands the layout over when the incoming branch is created first', async () => {
+		const layoutId = 'card-create-first';
+		const { parentB, outgoing } = await setup(layoutId);
+
+		const incoming = createNode(parentB, 200, 250, { layoutId, layout: true });
+
+		expect(incoming.resumeFrom).toBe(outgoing);
+		expect(incoming.snapshot?.layoutBox.x).toEqual({ min: 0, max: 50 });
+
+		outgoing.unmount();
+
+		expect(incoming.snapshot?.layoutBox.x).toEqual({ min: 0, max: 50 });
+	});
+
+	test('leaves the incoming node with an origin that differs from its new layout', async () => {
+		const layoutId = 'card-origin';
+		const { parentB, outgoing } = await setup(layoutId);
+
+		outgoing.unmount();
+
+		const incoming = createNode(parentB, 200, 250, { layoutId, layout: true });
+
+		incoming.willUpdate();
+		incoming.root.didUpdate();
+		await nextFrame();
+
+		expect(incoming.layout?.layoutBox.x).toEqual({ min: 200, max: 250 });
+		expect(incoming.snapshot?.layoutBox.x).not.toEqual(incoming.layout?.layoutBox.x);
+	});
+});

--- a/sites/playground/src/routes/tests/layout-shared-cross-parent.svelte
+++ b/sites/playground/src/routes/tests/layout-shared-cross-parent.svelte
@@ -1,0 +1,72 @@
+<svelte:options runes={true} />
+
+<script lang="ts">
+import { page } from '$app/state';
+import { LayoutGroup, motion, Reorder, useMotionValue } from 'motion-start';
+
+const variant = $derived(page.url.searchParams.get('variant') ?? 'plain');
+
+let column = $state(0);
+const values = [{ id: 'card' }];
+
+const x = useMotionValue(0);
+const y = useMotionValue(0);
+
+const transition = { duration: 0.5, ease: 'linear' } as const;
+</script>
+
+<button id="move" onclick={() => (column = column === 0 ? 1 : 0)}>move</button>
+
+<div class="board">
+	<LayoutGroup>
+		{#each [0, 1] as col (col)}
+			<div class="column" id={`column-${col}`}>
+				{#if variant === 'reorder'}
+					<Reorder.Group as="div" axis="y" {values} onReorder={() => {}}>
+						{#snippet children({ item })}
+							{#if column === col}
+								<Reorder.Item
+									as="div"
+									id="box"
+									value={item}
+									layoutId="box"
+									{transition}
+									style={{ background: 'red', width: '100px', height: '100px' }}
+								>
+									box
+								</Reorder.Item>
+							{/if}
+						{/snippet}
+					</Reorder.Group>
+				{:else if column === col}
+					<motion.div
+						id="box"
+						layout
+						layoutId="box"
+						{transition}
+						style={{
+							background: 'red',
+							width: '100px',
+							height: '100px',
+							...(variant === 'xy' ? { x, y } : {}),
+						}}
+					/>
+				{/if}
+			</div>
+		{/each}
+	</LayoutGroup>
+</div>
+
+<style>
+	.board {
+		display: flex;
+		gap: 200px;
+		padding: 20px;
+	}
+
+	.column {
+		width: 200px;
+		min-height: 300px;
+		background: #eee;
+	}
+</style>


### PR DESCRIPTION
## Summary

Investigation of a reported layout-animation gap: a `Reorder.Item` with a shared `layoutId` that unmounts from one `Reorder.Group` and mounts into another in the same update was said to teleport (`transform: none`) instead of running the shared-element transition.

**I could not reproduce the teleport in any environment I tested.** Details and per-frame evidence below. What this PR lands is the one genuine bug found along the way, plus regression coverage for the reported scenario so it stays fixed.

## The fix

`Reorder.Item` set `layoutDependency={orderVersion}` *after* the `{...props}` spread, so any `layoutDependency` a caller passed was silently overwritten. It was also redundant — `MeasureLayout` already folds the group's `orderVersion` into an *ambient* layout version, which by design adds snapshot opportunities rather than replacing the user's own dependency. The prop is now left alone.

## Regression coverage

**Unit** — `packages/motion-start/src/projection/node/__tests__/shared-remount.svelte.spec.ts`

Svelte, unlike React, does not rerender the outgoing shared element before the incoming one mounts, and the two branches can commit in either order depending on where they sit in the tree. Both orders are now covered:

- outgoing branch destroyed first (handover via the snapshot `unmount()` takes through `willUpdate()`)
- incoming branch created first (handover via `NodeStack.promote`'s `cloneMeasurements` fallback)
- the incoming node ends up with an origin that differs from its new layout, i.e. there is something to animate

**E2E** — `cypress/integration/layout-shared-cross-parent.ts` + `sites/playground/src/routes/tests/layout-shared-cross-parent.svelte`

Two containers in one `LayoutGroup`; the element moves between them with a shared `layoutId`. Three variants: plain `motion.div`, `motion.div` with explicit `x`/`y` motion values, and `Reorder.Item`. The spec samples `getBoundingClientRect().left` per `requestAnimationFrame` and asserts there are distinct intermediate frames — a single jump fails. Per-frame sampling is the only way to tell a fast animation apart from no animation.

## What I measured, and why I think it isn't broken

All measurements are per animation frame in a real browser.

| Scenario | Result |
| --- | --- |
| Minimal cross-parent fixture, `plain` / `xy` / `reorder` | smooth, 20 → 420 over ~30 frames |
| Same, against the packaged `dist` rather than `src` | smooth, 32 → 245 over ~16 frames |
| Playground `/demo/kanban-board`, cross-column ArrowRight | smooth, 143 → 390 over ~15 frames, real `matrix()` every frame |
| A 1:1 port of the reported-broken kanban demo, ArrowDown / ArrowRight / ArrowRight-while-scrolled | all smooth |

Specifically ruled out:

- **The `x`/`y` motion value hypothesis is disproved.** The `xy` variant — a plain `motion.div` with explicit `x`/`y` motion values sitting at 0, exactly what `Reorder.Item` passes — animates identically to the plain one. The initial style build does not stomp the projection transform.
- `src` vs. the packaged `dist`: no difference.
- Page scroll offset: no difference.
- The `layoutDependency` prop-order fix in this PR: correct, but not the cause — the transition animated correctly both before and after it.
- Plain `motion` element vs. `Reorder.Item`: no difference.
- Item objects mutated in place (stable `{#each}` keys, only the inner `{#if}` flips — the pure remount case) vs. replaced wholesale: no difference.

## Verification

- `vitest run` in `packages/motion-start`: **574 passed, 1 skipped, no type errors**
- Cypress: `animate-presence-*`, `drag-to-reorder`, `kanban-cross-column-reorder`, `layout-shared`, `layout-shared-cross-parent` — all green (`animate-presence-outro` flaked once in a batch run and passes on its own)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `Reorder.Item` now preserves caller-supplied layout dependencies.
  * Improved shared layout transitions when elements move between different parent containers.
  * Maintains smooth position animations regardless of transition commit order.

* **Tests**
  * Added coverage for shared-layout handoffs, remounts, reorder scenarios, and frame-by-frame animation behavior.
  * Added an interactive test page for validating cross-parent layout transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->