### PR TITLE
refactor: use reactive layout invalidation

### DIFF
--- a/.changeset/calm-motions-react.md
+++ b/.changeset/calm-motions-react.md
@@ -1,0 +1,5 @@
+---
+"motion-start": patch
+---
+
+Expose explicit reactive `MotionValue.current` reads and replace layout version counters with reusable Svelte invalidation signals.

--- a/packages/motion-start/src/components/AnimatePresence/AnimatePresence.svelte
+++ b/packages/motion-start/src/components/AnimatePresence/AnimatePresence.svelte
@@ -6,6 +6,7 @@ Copyright (c) 2018 Framer B.V. -->
 import { onMount } from 'svelte';
 import { useMotionConfigContext } from '../../context/MotionConfigContext.svelte.js';
 import { setMotionOutroContext } from '../../context/OutroContext.svelte.js';
+import { createReactiveInvalidation } from '../../utils/reactive-invalidation.js';
 import PresenceChild from './PresenceChild/PresenceChild.svelte';
 import type { AnimatePresenceProps } from './types.js';
 
@@ -22,7 +23,7 @@ const motionConfig = useMotionConfigContext();
 let activeOutros = 0;
 let waitUntil = 0;
 const exitWaiters: VoidFunction[] = [];
-let presenceLayoutVersion = $state(0);
+const layoutInvalidation = createReactiveInvalidation();
 let isInitialRender = $state(true);
 
 onMount(() => {
@@ -43,7 +44,7 @@ setMotionOutroContext({
 		return presenceAffectsLayout;
 	},
 	begin() {
-		if (presenceAffectsLayout) presenceLayoutVersion++;
+		if (presenceAffectsLayout) layoutInvalidation.invalidate();
 		activeOutros++;
 		let completed = false;
 
@@ -51,7 +52,7 @@ setMotionOutroContext({
 			if (completed) return;
 			completed = true;
 			activeOutros--;
-			if (presenceAffectsLayout) presenceLayoutVersion++;
+			if (presenceAffectsLayout) layoutInvalidation.invalidate();
 			if (activeOutros === 0) {
 				for (const resolve of exitWaiters.splice(0)) resolve();
 				if (completedExit) onExitComplete?.();
@@ -80,8 +81,8 @@ because Svelte's keyed blocks own their identity and DOM lifetime.
 	isPresent={true}
 	initial={initial === false && isInitialRender ? false : undefined}
 	{custom}
-	{presenceLayoutVersion}
 	{presenceAffectsLayout}
+	presenceLayoutInvalidation={layoutInvalidation}
 >
 	{@render children?.()}
 </PresenceChild>

--- a/packages/motion-start/src/components/AnimatePresence/PresenceChild/PresenceChild.svelte
+++ b/packages/motion-start/src/components/AnimatePresence/PresenceChild/PresenceChild.svelte
@@ -23,7 +23,7 @@ function newChildrenMap(): Map<string | number, boolean> {
 		onExitComplete = undefined,
 		initial,
 		custom = undefined,
-		presenceLayoutVersion = 0,
+		presenceLayoutInvalidation,
 		presenceAffectsLayout,
 		mode,
 		children: desendants,
@@ -52,9 +52,6 @@ function newChildrenMap(): Map<string | number, boolean> {
 	};
 
 	let measurePop = $state<Attachment | undefined>();
-	const layoutVersion = $derived(
-		presenceAffectsLayout && presenceLayoutVersion !== undefined ? presenceLayoutVersion : 0,
-	);
 
 	const context: PresenceContext = {
 		id,
@@ -75,8 +72,8 @@ function newChildrenMap(): Map<string | number, boolean> {
 		get custom() {
 			return custom;
 		},
-		get presenceLayoutVersion() {
-			return layoutVersion;
+		get presenceLayoutInvalidation() {
+			return presenceAffectsLayout ? presenceLayoutInvalidation : undefined;
 		},
 	};
 

--- a/packages/motion-start/src/components/AnimatePresence/PresenceChild/types.ts
+++ b/packages/motion-start/src/components/AnimatePresence/PresenceChild/types.ts
@@ -1,5 +1,6 @@
-import type { VariantLabels } from '../../../motion/types.js';
 import type { Snippet } from 'svelte';
+import type { VariantLabels } from '../../../motion/types.js';
+import type { ReactiveInvalidation } from '../../../utils/reactive-invalidation.js';
 
 export interface PresenceChildProps {
 	presenceKey?: string | number;
@@ -7,7 +8,7 @@ export interface PresenceChildProps {
 	onExitComplete?: () => void;
 	initial?: false | VariantLabels;
 	custom?: any;
-	presenceLayoutVersion?: number;
+	presenceLayoutInvalidation?: ReactiveInvalidation;
 	presenceAffectsLayout: boolean;
 	mode: 'wait' | 'sync' | 'popLayout';
 	children: Snippet;

--- a/packages/motion-start/src/components/Reorder/Group.svelte
+++ b/packages/motion-start/src/components/Reorder/Group.svelte
@@ -64,6 +64,7 @@ function compareMin<V>(a: ItemData<V>, b: ItemData<V>) {
 	import { motion } from "../../render/components/motion/proxy.js";
 	import type { HTMLMotionProps } from "../../render/html/types.js";
 	import { invariant } from "../../utils/errors.js";
+	import { createReactiveInvalidation } from "../../utils/reactive-invalidation.js";
 	import type { Ref } from "../../utils/safe-react-types.js";
 
 	import type { PropsWithChildren } from "../../utils/types.js";
@@ -98,7 +99,7 @@ function compareMin<V>(a: ItemData<V>, b: ItemData<V>) {
 	);
 
 	let order: ItemData<V>[] = [];
-	let orderVersion = $state(0);
+	const layoutInvalidation = createReactiveInvalidation();
 
 	// Guard against multiple onReorder calls in the same render cycle.
 	let isReordering = false;
@@ -117,9 +118,7 @@ function compareMin<V>(a: ItemData<V>, b: ItemData<V>) {
 		get axis() {
 			return axis;
 		},
-		get orderVersion() {
-			return orderVersion;
-		},
+		layoutInvalidation,
 		registerItem: (value, layout) => {
 			const idx = order.findIndex((entry) => value === entry.value);
 			if (idx !== -1) {
@@ -136,7 +135,7 @@ function compareMin<V>(a: ItemData<V>, b: ItemData<V>) {
 			if (order !== newOrder) {
 				isReordering = true;
 				order = newOrder;
-				orderVersion++;
+				layoutInvalidation.invalidate();
 				const reordered = newOrder
 					.map(getValue)
 					.filter((value) => values.includes(value));

--- a/packages/motion-start/src/components/Reorder/Item.svelte
+++ b/packages/motion-start/src/components/Reorder/Item.svelte
@@ -92,8 +92,8 @@ function useDefaultMotionValue(value: any, defaultValue = 0) {
 </script>
 
 <!--
-	`layoutDependency` is deliberately not set here. The group's `orderVersion`
-	already reaches every item as an *ambient* layout version (see
+	`layoutDependency` is deliberately not set here. The group's
+	`layoutInvalidation` already reaches every item as an ambient dependency (see
 	`MeasureLayout`), which adds snapshot opportunities without replacing the
 	user's own dependency. Setting it as a prop here would land after `{...props}`
 	and silently discard a `layoutDependency` the caller passed in — which a board

--- a/packages/motion-start/src/components/Reorder/__tests__/reorder-group.svelte.spec.ts
+++ b/packages/motion-start/src/components/Reorder/__tests__/reorder-group.svelte.spec.ts
@@ -17,6 +17,40 @@ function box(min: number, max: number): Box {
 }
 
 describe('Reorder.Group order reconciliation', () => {
+	it('invalidates layout only when updateOrder produces a real reorder', () => {
+		const captured: { context: ReorderContext<string> | null } = { context: null };
+
+		instance = mount(ReorderGroupFixture, {
+			target: document.body,
+			props: {
+				onReorder: () => undefined,
+				oncontext: (context: ReorderContext<string> | null) => {
+					captured.context = context;
+				},
+			},
+		});
+		flushSync();
+
+		const context = captured.context;
+		if (!context) throw new Error('Reorder.Group did not provide a context');
+
+		expect(context).not.toHaveProperty('orderVersion');
+		expect(context.layoutInvalidation).toBeDefined();
+
+		context.registerItem('a', box(0, 50));
+		context.registerItem('b', box(50, 150));
+		context.registerItem('c', box(150, 200));
+		context.registerItem('d', box(200, 350));
+
+		const initialToken = context.layoutInvalidation.current;
+
+		context.updateOrder('b', 0, 1);
+		expect(context.layoutInvalidation.current).toBe(initialToken);
+
+		context.updateOrder('b', 30, 1);
+		expect(context.layoutInvalidation.current).not.toBe(initialToken);
+	});
+
 	it('ignores items removed from values when picking the next reorder target', async () => {
 		const reorders: string[][] = [];
 		const captured: { context: ReorderContext<string> | null } = { context: null };

--- a/packages/motion-start/src/components/Reorder/types.ts
+++ b/packages/motion-start/src/components/Reorder/types.ts
@@ -1,10 +1,16 @@
 import type { Axis, Box } from '../../projection/geometry/types.js';
+import type { ReactiveInvalidation } from '../../utils/reactive-invalidation.js';
 
 export interface ReorderContext<T> {
 	axis: 'x' | 'y';
 	registerItem: (item: T, layout: Box) => void;
 	updateOrder: (item: T, offset: number, velocity: number) => void;
-	orderVersion?: number;
+	/**
+	 * A stable, reactive invalidation token. It only changes when
+	 * `updateOrder` produces a genuinely new order, so consumers can use it
+	 * as a layout dependency without re-snapshotting on every drag tick.
+	 */
+	layoutInvalidation: ReactiveInvalidation;
 }
 
 export interface ItemData<T> {

--- a/packages/motion-start/src/context/PresenceContext.svelte.ts
+++ b/packages/motion-start/src/context/PresenceContext.svelte.ts
@@ -6,6 +6,7 @@ Copyright (c) 2018 Framer B.V.
 import { createContext } from 'svelte';
 import type { Attachment } from 'svelte/attachments';
 import type { VariantLabels } from '../motion/types.js';
+import type { ReactiveInvalidation } from '../utils/reactive-invalidation.js';
 
 /**
  * @public
@@ -18,7 +19,7 @@ export interface PresenceContext {
 	measurePop?: Attachment;
 	initial?: false | VariantLabels;
 	custom?: any;
-	presenceLayoutVersion?: number;
+	presenceLayoutInvalidation?: ReactiveInvalidation;
 }
 
 const [getPresenceContext, setPresenceContext] = createContext<PresenceContext | null>();
@@ -31,4 +32,4 @@ function usePresenceContext() {
 	}
 }
 
-export { usePresenceContext, setPresenceContext };
+export { setPresenceContext, usePresenceContext };

--- a/packages/motion-start/src/easing/types.ts
+++ b/packages/motion-start/src/easing/types.ts
@@ -3,7 +3,14 @@ based on framer-motion@11.11.11,
 Copyright (c) 2018 Framer B.V.
 */
 
-export type EasingFunction = (v: number) => number;
+import type { EasingFunction as SvelteEasingFunction } from 'svelte/transition';
+
+/**
+ * Based on the public `EasingFunction` type exported by `svelte/transition`,
+ * so Motion easing callbacks are structurally compatible with Svelte's own
+ * transition easing option.
+ */
+export type EasingFunction = SvelteEasingFunction;
 
 export type EasingModifier = (easing: EasingFunction) => EasingFunction;
 

--- a/packages/motion-start/src/motion/features/layout/MeasureLayout.svelte
+++ b/packages/motion-start/src/motion/features/layout/MeasureLayout.svelte
@@ -15,12 +15,13 @@ interface MeasureContextProps {
 	safeToRemove?: VoidFunction | null;
 	measurePop?: import('svelte/attachments').Attachment | null;
 	/**
-	 * Version counters contributed by an enclosing `AnimatePresence` or `Reorder`
-	 * group. These are separate from `layoutDependency` because they are ambient:
-	 * an element inherits them without opting in, so they must add snapshot
-	 * opportunities rather than replace the user's own dependency.
+	 * A stable dependency contributed by an enclosing `AnimatePresence` or
+	 * `Reorder` group's `layoutInvalidation` tokens. This is separate from
+	 * `layoutDependency` because it is ambient: an element inherits it
+	 * without opting in, so it must add snapshot opportunities rather than
+	 * replace the user's own dependency.
 	 */
-	ambientLayoutVersion?: unknown;
+	ambientLayoutDependency?: unknown;
 }
 
 export interface MeasureProps extends MotionProps, MeasureContextProps {
@@ -56,16 +57,15 @@ export const animateLayout = {
 
 	// measurePop is set by PopChild when mode="popLayout".
 	const presenceMeasurePop = $derived(presenceContext?.measurePop);
-	const presenceLayoutDependency = $derived(presenceContext?.presenceLayoutVersion);
+	const presenceLayoutDependency = $derived(presenceContext?.presenceLayoutInvalidation?.current);
 
-	const reorderLayoutDependency = $derived(reorderContext?.orderVersion);
+	const reorderLayoutDependency = $derived(reorderContext?.layoutInvalidation?.current);
 
 	// Both contexts can be active at once (a reordered list inside an
-	// AnimatePresence), so combine them into a single comparable token rather
-	// than letting one mask updates from the other.
-	const ambientLayoutVersion = $derived(
-		`${String(reorderLayoutDependency)}:${String(presenceLayoutDependency)}`,
-	);
+	// AnimatePresence), so combine their opaque tokens into a single tuple
+	// rather than stringifying them — a fresh tuple is only produced when one
+	// of the underlying tokens actually changes.
+	const ambientLayoutDependency = $derived([reorderLayoutDependency, presenceLayoutDependency]);
 
 	// custom can still serve as a local layout dependency when no explicit
 	// layoutDependency is provided.
@@ -77,7 +77,7 @@ export const animateLayout = {
 <MeasureLayoutWithContext
 	{...props}
 	layoutDependency={props.layoutDependency ?? props.custom}
-	{ambientLayoutVersion}
+	{ambientLayoutDependency}
 	measurePop={presenceMeasurePop}
 	{layoutGroup}
 	switchLayoutGroup={useSwitchLayoutGroupContext() ?? undefined}

--- a/packages/motion-start/src/motion/features/layout/MeasureLayoutWithContext.svelte
+++ b/packages/motion-start/src/motion/features/layout/MeasureLayoutWithContext.svelte
@@ -26,7 +26,10 @@ const defaultScaleCorrectors = {
 };
 
 const props: MeasureProps = $props();
-const safeToRemove = () => props.safeToRemove?.();
+let isDestroyed = false;
+const safeToRemove = () => {
+	if (!isDestroyed) props.safeToRemove?.();
+};
 
 /**
  * Framer-motion runs `getSnapshotBeforeUpdate` on every render of the motion
@@ -61,7 +64,7 @@ onMount(() => {
 		}
 
 		tick().then(() => {
-			if (visualElement?.projection === projection) {
+			if (!isDestroyed && visualElement?.projection === projection) {
 				projection.root!.didUpdate();
 			}
 		});
@@ -81,11 +84,12 @@ let hasCompletedInitialPrepass = false;
 let isProjectionFlushPending = false;
 
 function scheduleProjectionFlush() {
-	if (isProjectionFlushPending) return;
+	if (isDestroyed || isProjectionFlushPending) return;
 	isProjectionFlushPending = true;
 
 	tick().then(() => {
 		isProjectionFlushPending = false;
+		if (isDestroyed) return;
 
 		const { visualElement, measurePop } = props;
 		const projection = visualElement?.projection;
@@ -96,7 +100,7 @@ function scheduleProjectionFlush() {
 		}
 		projection.root!.didUpdate();
 		microtask.postRender(() => {
-			if (!projection.currentAnimation && projection.isLead()) {
+			if (!isDestroyed && !projection.currentAnimation && projection.isLead()) {
 				safeToRemove();
 			}
 		});
@@ -164,6 +168,9 @@ watch.pre(
 );
 
 onDestroy(() => {
+	isDestroyed = true;
+	isProjectionFlushPending = false;
+
 	const { visualElement, layoutGroup, switchLayoutGroup } = props;
 	if (visualElement?.projection) {
 		const { projection } = visualElement;

--- a/packages/motion-start/src/motion/features/layout/MeasureLayoutWithContext.svelte
+++ b/packages/motion-start/src/motion/features/layout/MeasureLayoutWithContext.svelte
@@ -77,10 +77,31 @@ onMount(() => {
 	globalProjectionState.hasEverUpdated = true;
 });
 
-// Incremented for every relevant wrapper update so the post-commit
-// projection flush mirrors Framer's componentDidUpdate lifecycle.
-let updateVersion = $state(0);
 let hasCompletedInitialPrepass = false;
+let isProjectionFlushPending = false;
+
+function scheduleProjectionFlush() {
+	if (isProjectionFlushPending) return;
+	isProjectionFlushPending = true;
+
+	tick().then(() => {
+		isProjectionFlushPending = false;
+
+		const { visualElement, measurePop } = props;
+		const projection = visualElement?.projection;
+		if (!projection) return;
+
+		if (measurePop) {
+			measurePop(visualElement.current as HTMLElement | SVGElement);
+		}
+		projection.root!.didUpdate();
+		microtask.postRender(() => {
+			if (!projection.currentAnimation && projection.isLead()) {
+				safeToRemove();
+			}
+		});
+	});
+}
 
 // Pre-commit snapshot phase. This is the Svelte analogue of
 // getSnapshotBeforeUpdate in framer-motion's MeasureLayout.
@@ -88,18 +109,18 @@ watch.pre(
 	[
 		() => renderSnapshot,
 		() => props.layoutDependency,
-		() => props.ambientLayoutVersion,
+		() => props.ambientLayoutDependency,
 		() => props.drag,
 		() => props.visualElement?.projection,
 		() => props.isPresent,
 	],
-	(_currentValues, [, prevLayoutDependency, prevAmbientLayoutVersion, , , prevIsPresent]) => {
-		const { layoutDependency, ambientLayoutVersion, visualElement, isPresent } = props;
+	(_currentValues, [, prevLayoutDependency, prevAmbientLayoutDependency, , , prevIsPresent]) => {
+		const { layoutDependency, ambientLayoutDependency, visualElement, isPresent } = props;
 		const projection = visualElement?.projection;
 		const shouldSnapshot =
 			props.drag ||
 			prevLayoutDependency !== layoutDependency ||
-			prevAmbientLayoutVersion !== ambientLayoutVersion ||
+			prevAmbientLayoutDependency !== ambientLayoutDependency ||
 			layoutDependency === undefined;
 
 		if (!projection) {
@@ -138,31 +159,9 @@ watch.pre(
 			}
 		}
 
-		updateVersion++;
+		scheduleProjectionFlush();
 	}
 );
-
-// Post-commit projection flush. Runs after the relevant pre-pass so
-// projection.root.didUpdate() sees the committed DOM.
-watch([() => updateVersion, () => props.visualElement?.projection], () => {
-	const { measurePop } = props;
-	const { visualElement } = props;
-
-	tick().then(() => {
-		if (!updateVersion || !visualElement?.projection) return;
-
-		const { projection } = visualElement;
-		if (measurePop) {
-			measurePop(visualElement.current as HTMLElement | SVGElement);
-		}
-		projection.root!.didUpdate();
-		microtask.postRender(() => {
-			if (!projection.currentAnimation && projection.isLead()) {
-				safeToRemove();
-			}
-		});
-	});
-});
 
 onDestroy(() => {
 	const { visualElement, layoutGroup, switchLayoutGroup } = props;

--- a/packages/motion-start/src/render/dom/motion-outro.ts
+++ b/packages/motion-start/src/render/dom/motion-outro.ts
@@ -286,7 +286,7 @@ function makePresenceContext(
 		get custom() {
 			return context.custom;
 		},
-		presenceLayoutVersion: previous?.presenceLayoutVersion,
+		presenceLayoutInvalidation: previous?.presenceLayoutInvalidation,
 	};
 }
 

--- a/packages/motion-start/src/utils/__tests__/ReactiveInvalidationEffectFixture.svelte
+++ b/packages/motion-start/src/utils/__tests__/ReactiveInvalidationEffectFixture.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes />
+
 <script lang="ts">
 import type { createReactiveInvalidation } from '../reactive-invalidation.js';
 

--- a/packages/motion-start/src/utils/__tests__/ReactiveInvalidationEffectFixture.svelte
+++ b/packages/motion-start/src/utils/__tests__/ReactiveInvalidationEffectFixture.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+import type { createReactiveInvalidation } from '../reactive-invalidation.js';
+
+interface Props {
+	invalidation: ReturnType<typeof createReactiveInvalidation>;
+	onrun: (token: unknown) => void;
+}
+
+let { invalidation, onrun }: Props = $props();
+
+$effect(() => {
+	onrun(invalidation.current);
+});
+</script>

--- a/packages/motion-start/src/utils/__tests__/reactive-invalidation.svelte.spec.ts
+++ b/packages/motion-start/src/utils/__tests__/reactive-invalidation.svelte.spec.ts
@@ -1,0 +1,49 @@
+import { flushSync, mount, unmount } from 'svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createReactiveInvalidation } from '../reactive-invalidation.js';
+import ReactiveInvalidationEffectFixture from './ReactiveInvalidationEffectFixture.svelte';
+
+let instance: ReturnType<typeof mount> | undefined;
+
+afterEach(async () => {
+	if (instance) await unmount(instance);
+	instance = undefined;
+	document.body.innerHTML = '';
+});
+
+describe('createReactiveInvalidation', () => {
+	it('changes its current token on every invalidation', () => {
+		const invalidation = createReactiveInvalidation();
+		const tokens = [invalidation.current];
+
+		invalidation.invalidate();
+		tokens.push(invalidation.current);
+		invalidation.invalidate();
+		tokens.push(invalidation.current);
+
+		expect(new Set(tokens).size).toBe(3);
+	});
+
+	it('reruns dependent effects once per flushed invalidation and unsubscribes on teardown', async () => {
+		const invalidation = createReactiveInvalidation();
+		const onrun = vi.fn();
+
+		instance = mount(ReactiveInvalidationEffectFixture, {
+			target: document.body,
+			props: { invalidation, onrun },
+		});
+		flushSync();
+
+		invalidation.invalidate();
+		flushSync();
+		invalidation.invalidate();
+		flushSync();
+
+		await unmount(instance);
+		instance = undefined;
+		invalidation.invalidate();
+		flushSync();
+
+		expect(onrun).toHaveBeenCalledTimes(3);
+	});
+});

--- a/packages/motion-start/src/utils/reactive-invalidation.ts
+++ b/packages/motion-start/src/utils/reactive-invalidation.ts
@@ -1,0 +1,59 @@
+import { createSubscriber } from 'svelte/reactivity';
+
+/**
+ * An opaque token that changes identity every time `invalidate()` is called.
+ * Consumers should never rely on its shape — only on whether it is
+ * reference-equal to a previously observed token.
+ */
+declare const invalidationToken: unique symbol;
+export type InvalidationToken = Readonly<{ [invalidationToken]: true }>;
+
+/**
+ * @internal
+ */
+export interface ReactiveInvalidation {
+	/**
+	 * Reading `current` inside a `$derived` or `$effect` registers it as a
+	 * reactive dependency: whenever `invalidate()` is called, tracked effects
+	 * re-run. Outside of a reactive context this simply returns the latest
+	 * token without subscribing.
+	 */
+	readonly current: InvalidationToken;
+	/**
+	 * Produces a new, distinct token and notifies any tracked effects.
+	 * Safe to call before anything has subscribed to `current`.
+	 */
+	invalidate(): void;
+}
+
+/**
+ * Creates a lightweight reactive invalidation signal backed by Svelte's
+ * `createSubscriber`. Reading `.current` inside an effect subscribes that
+ * effect to future `invalidate()` calls; the subscription is automatically
+ * torn down once no tracked effects remain.
+ *
+ * @internal
+ */
+export function createReactiveInvalidation(): ReactiveInvalidation {
+	let token = {} as InvalidationToken;
+	let notify: (() => void) | undefined;
+
+	const subscribe = createSubscriber((update) => {
+		notify = update;
+
+		return () => {
+			notify = undefined;
+		};
+	});
+
+	return {
+		get current() {
+			subscribe();
+			return token;
+		},
+		invalidate() {
+			token = {} as InvalidationToken;
+			notify?.();
+		},
+	};
+}

--- a/packages/motion-start/src/value/__tests__/MotionValueReactiveReadsFixture.svelte
+++ b/packages/motion-start/src/value/__tests__/MotionValueReactiveReadsFixture.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes />
+
 <script lang="ts">
 import type { MotionValue } from '../index.js';
 

--- a/packages/motion-start/src/value/__tests__/MotionValueReactiveReadsFixture.svelte
+++ b/packages/motion-start/src/value/__tests__/MotionValueReactiveReadsFixture.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+import type { MotionValue } from '../index.js';
+
+interface Props {
+	value: MotionValue<number>;
+	oncurrent: (latest: number) => void;
+	onget: (latest: number) => void;
+}
+
+let { value, oncurrent, onget }: Props = $props();
+
+$effect(() => {
+	oncurrent(value.current);
+});
+
+$effect(() => {
+	onget(value.get());
+});
+</script>

--- a/packages/motion-start/src/value/__tests__/motion-value-reactivity.svelte.spec.ts
+++ b/packages/motion-start/src/value/__tests__/motion-value-reactivity.svelte.spec.ts
@@ -1,0 +1,48 @@
+import { flushSync, mount, unmount } from 'svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { collectMotionValues, type MotionValue, motionValue } from '../index.js';
+import MotionValueReactiveReadsFixture from './MotionValueReactiveReadsFixture.svelte';
+
+let instance: ReturnType<typeof mount> | undefined;
+
+afterEach(async () => {
+	if (instance) await unmount(instance);
+	instance = undefined;
+	document.body.innerHTML = '';
+	collectMotionValues.current = undefined;
+});
+
+describe('MotionValue reactive reads', () => {
+	it('reruns effects that read current and preserves reactive get compatibility', () => {
+		const value = motionValue(0);
+		const oncurrent = vi.fn();
+		const onget = vi.fn();
+
+		instance = mount(MotionValueReactiveReadsFixture, {
+			target: document.body,
+			props: { value, oncurrent, onget },
+		});
+		flushSync();
+
+		value.set(1);
+		flushSync();
+
+		expect({
+			currentReads: oncurrent.mock.calls,
+			imperativeReads: onget.mock.calls,
+		}).toEqual({
+			currentReads: [[0], [1]],
+			imperativeReads: [[0], [1]],
+		});
+	});
+
+	it('continues collecting imperative get reads for computed MotionValues', () => {
+		const value = motionValue(0);
+		const collected: MotionValue[] = [];
+		collectMotionValues.current = collected;
+
+		value.get();
+
+		expect(collected).toEqual([value]);
+	});
+});

--- a/packages/motion-start/src/value/index.ts
+++ b/packages/motion-start/src/value/index.ts
@@ -357,20 +357,31 @@ export class MotionValue<V = any> {
 	 */
 	get current(): V {
 		this.#subscribe();
-		if (collectMotionValues.current) {
-			collectMotionValues.current.push(this);
-		}
+		this.#collect();
 		return this._current!;
 	}
 
 	/**
 	 * Returns the latest state of `MotionValue`.
-	 * Prefer `.current` in Svelte components for reactive reads.
+	 *
+	 * This remains reactive for backwards compatibility with existing Svelte
+	 * templates. Prefer `.current` in new Svelte components to make reactive
+	 * reads explicit.
 	 *
 	 * @public
 	 */
-	get() {
+	get(): V {
 		return this.current;
+	}
+
+	/**
+	 * Registers this `MotionValue` with the currently open
+	 * `collectMotionValues` session, if any.
+	 */
+	#collect() {
+		if (collectMotionValues.current) {
+			collectMotionValues.current.push(this);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- expose `MotionValue.current` as the explicit Svelte-reactive read while preserving reactive `get()` compatibility
- replace Reorder and AnimatePresence layout version counters with a reusable `createSubscriber`-backed invalidation signal
- remove the local MeasureLayout post-commit counter in favor of a deduplicated `tick()` flush
- reuse Svelte's public transition easing function type

## Validation
- `bun run test:run`
- `bun run check:package`
- `bun run build`
- Cypress: `drag-to-reorder`, `presence-affects-layout`, and `layout`

The existing nested `afterChildren` case in `animate-presence-outro` remains red on `main`; its fix is on `jonathonrp-fix-afterchildren-exit-order` and is unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reactive `MotionValue.current` reads for improved Svelte reactivity.
  * Improved layout updates for presence animations and reordered items.
  * Added reusable reactive invalidation support for coordinated updates.

* **Bug Fixes**
  * Improved layout projection flushing and synchronization after animations or reordering.

* **Tests**
  * Added coverage for reactive MotionValue reads, invalidation behavior, and reorder updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->