### PR TITLE
Fix Reorder production `true` output and source cleanup

### DIFF
--- a/.changeset/fuzzy-dragons-smile.md
+++ b/.changeset/fuzzy-dragons-smile.md
@@ -1,0 +1,5 @@
+---
+"motion-start": patch
+---
+
+Prevent `Reorder.Group` and `Reorder.Item` development assertions from rendering `true` in production output.

--- a/packages/motion-start/src/components/Reorder/Group.svelte
+++ b/packages/motion-start/src/components/Reorder/Group.svelte
@@ -84,6 +84,11 @@ function compareMin<V>(a: ItemData<V>, b: ItemData<V>) {
 		children: Snippet<[{ item: V; id: number }]>;
 	} = $props();
 
+	const validatedValues = $derived.by(() => {
+		invariant(Boolean(values), "Reorder.Group must be provided a values prop");
+		return values;
+	});
+
 	const axis = $derived(axisProp);
 
 	const component = $derived(as as keyof typeof motion);
@@ -108,7 +113,7 @@ function compareMin<V>(a: ItemData<V>, b: ItemData<V>) {
 	// and `order` lives for the lifetime of the group. Drop entries whose value
 	// is no longer rendered so removed items can't be picked as reorder targets.
 	function reconcileOrder() {
-		const present = new Set(values);
+		const present = new Set(validatedValues);
 		if (order.some((entry) => !present.has(entry.value))) {
 			order = order.filter((entry) => present.has(entry.value));
 		}
@@ -140,7 +145,7 @@ function compareMin<V>(a: ItemData<V>, b: ItemData<V>) {
 				order = newOrder;
 				const reordered = newOrder
 					.map(getValue)
-					.filter((value) => values.includes(value));
+					.filter((value) => validatedValues.includes(value));
 				// Wait for the active drag update, then publish the ambient layout
 				// invalidation in its own flush before onReorder can move keyed children.
 				tick().then(() => {
@@ -163,8 +168,7 @@ function compareMin<V>(a: ItemData<V>, b: ItemData<V>) {
 </script>
 
 <ReorderGroup {...props} bind:ref={externalRef} ignoreStrict>
-	{invariant(Boolean(values), "Reorder.Group must be provided a values prop")}
-	{#each values as item, indx (item)}
+	{#each validatedValues as item, indx (item)}
 		{@render children({ item, id: indx })}
 	{/each}
 </ReorderGroup>

--- a/packages/motion-start/src/components/Reorder/Item.svelte
+++ b/packages/motion-start/src/components/Reorder/Item.svelte
@@ -73,7 +73,12 @@ function useDefaultMotionValue(value: any, defaultValue = 0) {
 		>,
 	);
 
-	const context = $derived(useReorderContext());
+	const context = useReorderContext();
+	invariant(
+		Boolean(context),
+		"Reorder.Item must be a child of Reorder.Group",
+	);
+
 	function getInitialStyleValue(axis: "x" | "y") {
 		return style?.[axis];
 	}
@@ -134,9 +139,5 @@ function useDefaultMotionValue(value: any, defaultValue = 0) {
 	{layout}
 	ignoreStrict
 >
-	{invariant(
-		Boolean(context),
-		"Reorder.Item must be a child of Reorder.Group",
-	)}
 	{@render children()}
 </ReorderItem>

--- a/packages/motion-start/src/components/Reorder/__tests__/ReorderGroupInvariantFixture.svelte
+++ b/packages/motion-start/src/components/Reorder/__tests__/ReorderGroupInvariantFixture.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
 import Group from '../Group.svelte';
 

--- a/packages/motion-start/src/components/Reorder/__tests__/ReorderGroupInvariantFixture.svelte
+++ b/packages/motion-start/src/components/Reorder/__tests__/ReorderGroupInvariantFixture.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+import Group from '../Group.svelte';
+
+let values = $state<string[] | undefined>(['alpha']);
+</script>
+
+<button data-testid="remove-values" onclick={() => (values = undefined)}>remove values</button>
+
+<Group values={values!}>
+	{#snippet children({ item })}
+		<span>{item}</span>
+	{/snippet}
+</Group>

--- a/packages/motion-start/src/components/Reorder/__tests__/ReorderProductionSsrFixture.svelte
+++ b/packages/motion-start/src/components/Reorder/__tests__/ReorderProductionSsrFixture.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+import Group from '../Group.svelte';
+import Item from '../Item.svelte';
+
+interface Props {
+	withItem?: boolean;
+}
+
+let { withItem = false }: Props = $props();
+
+const values = ['alpha'];
+</script>
+
+<Group {values}>
+	{#snippet children({ item })}
+		{#if withItem}
+			<Item value={item}>
+				{#snippet children()}
+					<span data-testid="item-content">{item}</span>
+				{/snippet}
+			</Item>
+		{:else}
+			<span data-testid="group-content">{item}</span>
+		{/if}
+	{/snippet}
+</Group>

--- a/packages/motion-start/src/components/Reorder/__tests__/ReorderProductionSsrFixture.svelte
+++ b/packages/motion-start/src/components/Reorder/__tests__/ReorderProductionSsrFixture.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={true} />
+
 <script lang="ts">
 import Group from '../Group.svelte';
 import Item from '../Item.svelte';

--- a/packages/motion-start/src/components/Reorder/__tests__/production-ssr-entry.ts
+++ b/packages/motion-start/src/components/Reorder/__tests__/production-ssr-entry.ts
@@ -1,0 +1,11 @@
+import { render } from 'svelte/server';
+import Group from '../Group.svelte';
+import ReorderProductionSsrFixture from './ReorderProductionSsrFixture.svelte';
+
+export function renderFixture(withItem = false) {
+	return render(ReorderProductionSsrFixture, { props: { withItem } }).body;
+}
+
+export function renderGroupWithoutValues() {
+	return render(Group, { props: {} as never }).body;
+}

--- a/packages/motion-start/src/components/Reorder/__tests__/reorder-group.svelte.spec.ts
+++ b/packages/motion-start/src/components/Reorder/__tests__/reorder-group.svelte.spec.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import type { Box } from '../../../projection/geometry/types.js';
 import type { ReorderContext } from '../types.js';
 import ReorderGroupFixture from './ReorderGroupFixture.svelte';
+import ReorderGroupInvariantFixture from './ReorderGroupInvariantFixture.svelte';
 
 let instance: ReturnType<typeof mount> | undefined;
 
@@ -21,6 +22,22 @@ function getRenderedItems() {
 }
 
 describe('Reorder.Group order reconciliation', () => {
+	it('throws if values becomes missing in development', () => {
+		instance = mount(ReorderGroupInvariantFixture, {
+			target: document.body,
+		});
+		flushSync();
+
+		const removeValues = document.querySelector('[data-testid="remove-values"]');
+		if (!(removeValues instanceof HTMLButtonElement)) {
+			throw new Error('Missing remove-values button');
+		}
+
+		expect(() => {
+			flushSync(() => removeValues.click());
+		}).toThrowError('Reorder.Group must be provided a values prop');
+	});
+
 	it('publishes layout invalidation before updating keyed children', async () => {
 		const captured: { context: ReorderContext<string> | null } = { context: null };
 		const reorderSnapshots: Array<{

--- a/packages/motion-start/src/components/Reorder/__tests__/reorder-production-ssr.svelte.spec.ts
+++ b/packages/motion-start/src/components/Reorder/__tests__/reorder-production-ssr.svelte.spec.ts
@@ -1,0 +1,92 @@
+// @vitest-environment node
+
+import { fileURLToPath } from 'node:url';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { build } from 'vite';
+import { describe, expect, it } from 'vitest';
+
+type SsrEnvironment = 'development' | 'production';
+
+type SsrFixtureModule = {
+	renderFixture: (withItem?: boolean) => string;
+	renderGroupWithoutValues: () => string;
+};
+
+const ssrModules = new Map<SsrEnvironment, Promise<SsrFixtureModule>>();
+
+function loadSsrModule(environment: SsrEnvironment) {
+	let ssrModule = ssrModules.get(environment);
+	if (ssrModule) return ssrModule;
+
+	// Bundle the fixture with Svelte's server runtime so its render helper and
+	// components share one SSR context when the in-memory chunk is imported.
+	ssrModule = build({
+		root: fileURLToPath(new URL('../../../../', import.meta.url)),
+		configFile: false,
+		logLevel: 'silent',
+		plugins: [svelte()],
+		define: {
+			'process.env.NODE_ENV': JSON.stringify(environment),
+		},
+		build: {
+			ssr: 'src/components/Reorder/__tests__/production-ssr-entry.ts',
+			write: false,
+			rollupOptions: {
+				output: {
+					format: 'es',
+					inlineDynamicImports: true,
+				},
+			},
+		},
+		ssr: {
+			noExternal: true,
+		},
+	}).then(async (result) => {
+		const builds = Array.isArray(result) ? result : [result];
+		const entry = builds
+			.flatMap((buildResult) => ('output' in buildResult ? buildResult.output : []))
+			.find((output) => output.type === 'chunk' && output.isEntry);
+
+		if (entry?.type !== 'chunk') {
+			throw new Error('SSR build did not emit an entry chunk');
+		}
+
+		const url = `data:text/javascript;base64,${Buffer.from(entry.code).toString('base64')}`;
+		return (await import(/* @vite-ignore */ url)) as SsrFixtureModule;
+	});
+
+	ssrModules.set(environment, ssrModule);
+	return ssrModule;
+}
+
+function elementMarkup(body: string, tag: string, testId: string) {
+	const match = body.match(new RegExp(`<${tag}\\b[^>]*>[\\s\\S]*?data-testid="${testId}"[\\s\\S]*?</${tag}>`));
+	if (!match) throw new Error(`Could not find ${tag} containing ${testId}`);
+	return match[0];
+}
+
+describe('Reorder production SSR', () => {
+	it('does not render the Group values invariant result as literal text', async () => {
+		const { renderFixture } = await loadSsrModule('production');
+
+		const group = elementMarkup(renderFixture(), 'ul', 'group-content');
+
+		expect(group).not.toContain('true');
+	}, 30_000);
+
+	it('does not render the Item context invariant result as literal text', async () => {
+		const { renderFixture } = await loadSsrModule('production');
+
+		const item = elementMarkup(renderFixture(true), 'li', 'item-content');
+
+		expect(item).not.toContain('true');
+	}, 30_000);
+});
+
+describe('Reorder.Group development invariant', () => {
+	it('throws the established error when values is missing', async () => {
+		const { renderGroupWithoutValues } = await loadSsrModule('development');
+
+		expect(renderGroupWithoutValues).toThrowError('Reorder.Group must be provided a values prop');
+	}, 30_000);
+});

--- a/packages/motion-start/src/components/Reorder/__tests__/reorder-production-ssr.svelte.spec.ts
+++ b/packages/motion-start/src/components/Reorder/__tests__/reorder-production-ssr.svelte.spec.ts
@@ -1,6 +1,9 @@
 // @vitest-environment node
 
-import { fileURLToPath } from 'node:url';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { build } from 'vite';
 import { describe, expect, it } from 'vitest';
@@ -19,41 +22,47 @@ function loadSsrModule(environment: SsrEnvironment) {
 	if (ssrModule) return ssrModule;
 
 	// Bundle the fixture with Svelte's server runtime so its render helper and
-	// components share one SSR context when the in-memory chunk is imported.
-	ssrModule = build({
-		root: fileURLToPath(new URL('../../../../', import.meta.url)),
-		configFile: false,
-		logLevel: 'silent',
-		plugins: [svelte()],
-		define: {
-			'process.env.NODE_ENV': JSON.stringify(environment),
-		},
-		build: {
-			ssr: 'src/components/Reorder/__tests__/production-ssr-entry.ts',
-			write: false,
-			rollupOptions: {
-				output: {
-					format: 'es',
-					inlineDynamicImports: true,
+	// components share one SSR context when the temporary chunk is imported.
+	ssrModule = (async () => {
+		const outDir = await mkdtemp(join(tmpdir(), 'motion-start-reorder-ssr-'));
+
+		try {
+			const result = await build({
+				root: fileURLToPath(new URL('../../../../', import.meta.url)),
+				configFile: false,
+				logLevel: 'silent',
+				plugins: [svelte()],
+				define: {
+					'process.env.NODE_ENV': JSON.stringify(environment),
 				},
-			},
-		},
-		ssr: {
-			noExternal: true,
-		},
-	}).then(async (result) => {
-		const builds = Array.isArray(result) ? result : [result];
-		const entry = builds
-			.flatMap((buildResult) => ('output' in buildResult ? buildResult.output : []))
-			.find((output) => output.type === 'chunk' && output.isEntry);
+				build: {
+					ssr: 'src/components/Reorder/__tests__/production-ssr-entry.ts',
+					outDir,
+					rollupOptions: {
+						output: {
+							format: 'es',
+							inlineDynamicImports: true,
+						},
+					},
+				},
+				ssr: {
+					noExternal: true,
+				},
+			});
+			const builds = Array.isArray(result) ? result : [result];
+			const entry = builds
+				.flatMap((buildResult) => ('output' in buildResult ? buildResult.output : []))
+				.find((output) => output.type === 'chunk' && output.isEntry);
 
-		if (entry?.type !== 'chunk') {
-			throw new Error('SSR build did not emit an entry chunk');
+			if (entry?.type !== 'chunk') {
+				throw new Error('SSR build did not emit an entry chunk');
+			}
+
+			return (await import(pathToFileURL(join(outDir, entry.fileName)).href)) as SsrFixtureModule;
+		} finally {
+			await rm(outDir, { recursive: true, force: true });
 		}
-
-		const url = `data:text/javascript;base64,${Buffer.from(entry.code).toString('base64')}`;
-		return (await import(/* @vite-ignore */ url)) as SsrFixtureModule;
-	});
+	})();
 
 	ssrModules.set(environment, ssrModule);
 	return ssrModule;


### PR DESCRIPTION
## Summary

- Execute `Reorder.Group` and `Reorder.Item` invariants in component script logic instead of rendering their return values.
- Preserve reactive development validation when `values` becomes missing.
- Add production-compiled SSR regressions for both components and a patch changeset.

## Cause and history

In production, `packages/motion-start/src/utils/errors.ts` aliases `invariant` to the generic `noop`, which returns its argument. Rendering `invariant(Boolean(...), ...)` in Svelte markup therefore emitted the returned `true` before Reorder/Kanban content. Development throws or returns `void`, so the leak was production-only.

The rendered assertion predates the monorepo: it is present in `5013e2b6` (`Feature/rewrite (#7)`) and was moved with the source during the monorepo restructure in #63 (`183c0fe6`) and related flattening work. It was not introduced by Kanban seed data.

## Source cleanup finding

Current `origin/main` is release PR #71's merge commit (`f6344ed1`). It has no tracked root `src` path, this clean checkout has no physical root `src` directory, `git status --ignored -- src` finds no residue, and no empty directories exist under the tracked source roots. Git does not encode empty directories, so there is no repository removal to commit for this part.

## Validation

- `bun run test:run`: 641 passed, 1 skipped
- Targeted Reorder regressions: 7 passed
- `bun run check:package`: 0 errors, 0 warnings
- `bun run build`: package build and strict publint passed

`bun run lint` remains blocked by existing repository-wide formatting debt (beginning with `.changeset/config.json`) and existing Biome Svelte cross-block false positives; changed files were formatted directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Reorder components so development-only validation messages no longer appear as literal `true` text in production-rendered output.
  * Improved handling when required reorder values are missing, while preserving the expected development-time error.
* **Tests**
  * Added coverage for client rendering and server-side rendering in both development and production modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->