### PR TITLE
fix(waapi): commit multi-word final keyframes to inline style

### DIFF
--- a/.changeset/wild-poems-commit.md
+++ b/.changeset/wild-poems-commit.md
@@ -1,0 +1,15 @@
+---
+"motion-start": patch
+---
+
+Fix WAAPI animations of multi-word CSS properties snapping back when they finish.
+
+`setStyle` committed the final keyframe with `element.style.setProperty(name, value)`. CSSOM
+lowercases the property name it is given but does not convert camelCase to kebab-case, so
+`setProperty("clipPath", ...)` became `"clippath"` and was silently discarded. Every
+`acceleratedValues` entry with more than one word - `clipPath`, `backgroundColor`, `borderRadius`
+and friends - therefore lost its end state the moment the animation was cancelled, producing the
+flash the commit is there to prevent. Only `opacity` and other single-word properties worked.
+
+The final keyframe is now assigned through the camelCase indexer, matching upstream, while CSS
+custom properties keep going through `setProperty`.

--- a/packages/motion-start/src/animation/animators/waapi/__tests__/animate-style.spec.ts
+++ b/packages/motion-start/src/animation/animators/waapi/__tests__/animate-style.spec.ts
@@ -128,6 +128,24 @@ describe.skipIf(typeof Element === 'undefined')('animateMini', () => {
 		expect(div.style.opacity).toBe('0.5');
 	});
 
+	test('applies multi-word target keyframe when animation has finished', async () => {
+		const div = document.createElement('div');
+		const animation = animateMini(div, { clipPath: 'inset(10%)' }, { duration });
+
+		await animation;
+
+		expect(div.style.clipPath).toBe('inset(10%)');
+	});
+
+	test('applies final multi-word target keyframe when animation has finished', async () => {
+		const div = document.createElement('div');
+		const animation = animateMini(div, { backgroundColor: ['rgb(255, 0, 0)', 'rgb(0, 0, 255)'] }, { duration });
+
+		await animation;
+
+		expect(div.style.backgroundColor).toBe('rgb(0, 0, 255)');
+	});
+
 	test('time sets and gets time', async () => {
 		const div = document.createElement('div');
 		const animation = animateMini(div, { opacity: 0.5 }, { duration: 10 });

--- a/packages/motion-start/src/animation/animators/waapi/utils/style.ts
+++ b/packages/motion-start/src/animation/animators/waapi/utils/style.ts
@@ -10,6 +10,12 @@ export function setCSSVar(element: HTMLElement, name: string, value: string | nu
 }
 
 export function setStyle(element: HTMLElement, name: string, value: string | number) {
-	// Use setProperty for safety since name is dynamic and may not be a known CSS property
-	element.style.setProperty(name, String(value));
+	// `setProperty` doesn't convert camelCase to kebab-case, so multi-word properties
+	// like `clipPath` would be silently dropped. Custom properties can only be set
+	// through `setProperty`.
+	if (name.startsWith('--')) {
+		element.style.setProperty(name, String(value));
+	} else {
+		element.style[name as MotionStyleKey] = value as never;
+	}
 }


### PR DESCRIPTION
## The bug

`setStyle` in `packages/motion-start/src/animation/animators/waapi/utils/style.ts` committed the final keyframe with `element.style.setProperty(name, String(value))`.

CSSOM's `setProperty` lowercases the property name it is given but does **not** convert camelCase to kebab-case, so `setProperty("clipPath", ...)` becomes `"clippath"`, which is not a real property, and the declaration is silently discarded.

`NativeAnimation.onFinish` writes the final keyframe with `setValue` and then immediately cancels the WAAPI animation. When the write is a no-op, cancelling drops the element straight back to its pre-animation value — exactly the flash the commit exists to prevent. `clipPath`, `backgroundColor`, `borderRadius` and every other multi-word member of `acceleratedValues` take the WAAPI path, so all of them were affected.

It went unnoticed because the only coverage was `opacity`, a single-word property whose name survives `setProperty` unchanged.

## The fix

Assign through the camelCase indexer, matching upstream framer-motion v11.11.11: `element.style[name as MotionStyleKey] = value as never`. CSS custom properties (`--*`) still go through `setProperty`, since the indexer does not work for those.

## Tests

Added two regression tests alongside the existing `opacity` cases in `waapi/__tests__/animate-style.spec.ts`, covering `clipPath` and `backgroundColor` and asserting the final keyframe lands in inline style after the animation finishes and is cancelled. Both fail against the old implementation (`expected '' to be 'inset(10%)'`) and pass with the fix; the existing `opacity` coverage stays green.

`vitest --run` on `packages/motion-start`: 620 passed. Two unrelated specs (`reorder-production-ssr`, `package-imports`) hit the 30s timeout under parallel load on this machine and pass in isolation.

A patch changeset is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed WAAPI animations so multi-word CSS properties retain their correct final values, including `clipPath`, `backgroundColor`, and `borderRadius`.
  * Improved handling of CSS custom properties during animation completion.

* **Tests**
  * Added coverage for completed single-value and multi-value animations involving multi-word CSS properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->