### PR TITLE
Fix animation replay and playback speed correctness

### DIFF
--- a/.changeset/shaggy-otters-replay.md
+++ b/.changeset/shaggy-otters-replay.md
@@ -1,0 +1,9 @@
+---
+"motion-start": patch
+---
+
+Fix animation replay and playback speed correctness.
+
+- A finished `MainThreadAnimation` can be replayed again: `play()` now rebases `startTime` on the current time before falling back to the animation's creation time, which previously made a replayed animation finish instantly.
+- `speed = -1` now plays a finished animation backwards. `play()` offsets `startTime` by the animation's duration when replaying in reverse, and changing `speed` brings the current time up to date before rebasing.
+- Animations that finish while reversed or at a non-default speed now commit the correct terminal keyframe. `getFinalKeyframe` accepts the playback speed and returns the first keyframe when the speed is negative, and both the WAAPI (`AcceleratedAnimation`) and mini (`NativeAnimation`) paths pass it through.

--- a/packages/motion-start/src/animation/animators/AcceleratedAnimation.ts
+++ b/packages/motion-start/src/animation/animators/AcceleratedAnimation.ts
@@ -226,7 +226,7 @@ export class AcceleratedAnimation<T extends string | number> extends BaseAnimati
 			 */
 			animation.onfinish = () => {
 				const { onComplete } = this.options;
-				const keyframe = getFinalKeyframe(keyframes, this.options, finalKeyframe);
+				const keyframe = getFinalKeyframe(keyframes, this.options, finalKeyframe, animation.playbackRate);
 				mv.set(keyframe);
 
 				/**

--- a/packages/motion-start/src/animation/animators/MainThreadAnimation.ts
+++ b/packages/motion-start/src/animation/animators/MainThreadAnimation.ts
@@ -21,6 +21,7 @@ import { millisecondsToSeconds, secondsToMilliseconds } from '../../utils/time-c
 import { clamp } from '../../utils/clamp.js';
 import { invariant } from '../../utils/errors.js';
 import { frameloopDriver } from './drivers/driver-frameloop.js';
+import { time } from '../../frameloop/sync-time.js';
 import { getFinalKeyframe } from './waapi/utils/get-final-keyframe.js';
 import { isGenerator } from '../generators/utils/is-generator.js';
 
@@ -206,6 +207,21 @@ export class MainThreadAnimation<T extends string | number> extends BaseAnimatio
 		}
 	}
 
+	/**
+	 * Update the animation's currentTime based on the provided timestamp,
+	 * the animation's startTime and its playback speed.
+	 */
+	private updateTime(timestamp: number) {
+		if (this.holdTime !== null) {
+			this.currentTime = this.holdTime;
+		} else {
+			// Rounding the time because floating point arithmetic is not always accurate, e.g. 3000.367 - 1000.367 =
+			// 2000.0000000000002. This is a problem when we are comparing the currentTime with the duration, for
+			// example.
+			this.currentTime = Math.round(timestamp - this.startTime!) * this.speed;
+		}
+	}
+
 	tick(timestamp: number, sample = false) {
 		const { resolved } = this;
 
@@ -245,13 +261,8 @@ export class MainThreadAnimation<T extends string | number> extends BaseAnimatio
 		// Update currentTime
 		if (sample) {
 			this.currentTime = timestamp;
-		} else if (this.holdTime !== null) {
-			this.currentTime = this.holdTime;
 		} else {
-			// Rounding the time because floating point arithmetic is not always accurate, e.g. 3000.367 - 1000.367 =
-			// 2000.0000000000002. This is a problem when we are comparing the currentTime with the duration, for
-			// example.
-			this.currentTime = Math.round(timestamp - this.startTime) * this.speed;
+			this.updateTime(timestamp);
 		}
 
 		// Rebase on delay
@@ -340,7 +351,7 @@ export class MainThreadAnimation<T extends string | number> extends BaseAnimatio
 			this.holdTime === null && (this.state === 'finished' || (this.state === 'running' && done));
 
 		if (isAnimationFinished && finalKeyframe !== undefined) {
-			state.value = getFinalKeyframe(keyframes, this.options, finalKeyframe);
+			state.value = getFinalKeyframe(keyframes, this.options, finalKeyframe, this.speed);
 		}
 
 		if (onUpdate) {
@@ -382,8 +393,18 @@ export class MainThreadAnimation<T extends string | number> extends BaseAnimatio
 
 	set speed(newSpeed: number) {
 		const hasChanged = this.playbackSpeed !== newSpeed;
+
+		/**
+		 * Bring currentTime up to date before changing speed, otherwise the time
+		 * elapsed since the previous frame would be rebased at the new speed.
+		 */
+		if (hasChanged && this.driver) {
+			this.updateTime(time.now());
+		}
+
 		this.playbackSpeed = newSpeed;
-		if (hasChanged) {
+
+		if (hasChanged && this.driver) {
 			this.time = millisecondsToSeconds(this.currentTime);
 		}
 	}
@@ -409,16 +430,28 @@ export class MainThreadAnimation<T extends string | number> extends BaseAnimatio
 		onPlay && onPlay();
 
 		const now = this.driver.now();
-		if (this.holdTime !== null) {
+
+		/**
+		 * The finished check must come first: teardown() nulls startTime when an
+		 * animation finishes, so the `!this.startTime` branch would otherwise
+		 * rebuild it from the now-stale creation time and the animation would
+		 * immediately be "finished" again.
+		 */
+		if (this.state === 'finished') {
+			this.updateFinishedPromise();
+			this.startTime = now;
+		} else if (this.holdTime !== null) {
 			this.startTime = now - this.holdTime;
 		} else if (!this.startTime) {
 			this.startTime = startTime ?? this.calcStartTime();
-		} else if (this.state === 'finished') {
-			this.startTime = now;
 		}
 
-		if (this.state === 'finished') {
-			this.updateFinishedPromise();
+		/**
+		 * Replaying a finished animation in reverse needs to start from the end
+		 * of the animation rather than the beginning.
+		 */
+		if (this.state === 'finished' && this.speed < 0) {
+			this.startTime += this._resolved.calculatedDuration;
 		}
 
 		this.cancelTime = this.startTime;

--- a/packages/motion-start/src/animation/animators/__tests__/AcceleratedAnimation.spec.ts
+++ b/packages/motion-start/src/animation/animators/__tests__/AcceleratedAnimation.spec.ts
@@ -23,6 +23,31 @@ function restoreWaapi() {
 describe.skipIf(typeof Element === 'undefined')('AcceleratedAnimation', () => {
 	afterEach(restoreWaapi);
 
+	function createMockAnimation() {
+		let playState: AnimationPlayState = 'running';
+
+		const nativeAnimation = {
+			currentTime: 0,
+			playbackRate: 1,
+			get playState() {
+				return playState;
+			},
+			startTime: 0,
+			onfinish: null as ((event: AnimationPlaybackEvent) => void) | null,
+			play: vi.fn(),
+			pause: vi.fn(),
+			finish: vi.fn(() => {
+				playState = 'finished';
+				nativeAnimation.onfinish?.(new Event('finish') as AnimationPlaybackEvent);
+			}),
+			cancel: vi.fn(() => {
+				playState = 'idle';
+			}),
+		} as unknown as Animation;
+
+		return nativeAnimation;
+	}
+
 	test('commits the final style before cancelling a finished WAAPI animation', () => {
 		const element = document.createElement('div');
 		element.style.opacity = '1';
@@ -68,5 +93,62 @@ describe.skipIf(typeof Element === 'undefined')('AcceleratedAnimation', () => {
 		expect(opacity.get()).toBe(0);
 		expect(element.style.opacity).toBe('0');
 		expect(nativeAnimation.cancel).toHaveBeenCalledOnce();
+	});
+
+	/**
+	 * Regression test for https://github.com/motiondivision/motion/issues/3113
+	 * and https://github.com/motiondivision/motion/issues/2947
+	 */
+	test('commits the first keyframe when a WAAPI animation finishes in reverse', () => {
+		const element = document.createElement('div');
+		element.style.opacity = '1';
+
+		const nativeAnimation = createMockAnimation();
+		Element.prototype.animate = vi.fn(() => nativeAnimation);
+
+		const opacity = motionValue(1, {
+			owner: { current: element, getProps: () => ({}) },
+		});
+
+		const animation = new AcceleratedAnimation({
+			name: 'opacity',
+			motionValue: opacity,
+			keyframes: [1, 0],
+			duration: 100,
+		});
+
+		animation.speed = -1;
+		expect(animation.speed).toBe(-1);
+
+		animation.complete();
+
+		expect(opacity.get()).toBe(1);
+		expect(element.style.opacity).toBe('1');
+	});
+
+	test('commits the final keyframe when a WAAPI animation finishes at a non-default speed', () => {
+		const element = document.createElement('div');
+		element.style.opacity = '1';
+
+		const nativeAnimation = createMockAnimation();
+		Element.prototype.animate = vi.fn(() => nativeAnimation);
+
+		const opacity = motionValue(1, {
+			owner: { current: element, getProps: () => ({}) },
+		});
+
+		const animation = new AcceleratedAnimation({
+			name: 'opacity',
+			motionValue: opacity,
+			keyframes: [1, 0],
+			duration: 100,
+		});
+
+		animation.speed = 2;
+
+		animation.complete();
+
+		expect(opacity.get()).toBe(0);
+		expect(element.style.opacity).toBe('0');
 	});
 });

--- a/packages/motion-start/src/animation/animators/__tests__/MainThreadAnimation.spec.ts
+++ b/packages/motion-start/src/animation/animators/__tests__/MainThreadAnimation.spec.ts
@@ -9,7 +9,7 @@ import { MainThreadAnimation, animateValue } from '../MainThreadAnimation.js';
 import { reverseEasing } from '../../../easing/modifiers/reverse.js';
 import { noop } from '../../../utils/noop.js';
 import type { ValueAnimationOptions } from '../../types.js';
-import { syncDriver } from './utils.js';
+import { syncDriver, persistentSyncDriver } from './utils.js';
 import { KeyframeResolver } from '../../../render/utils/KeyframesResolver.js';
 
 /**
@@ -1380,5 +1380,62 @@ describe('MainThreadAnimation', () => {
 		animation.sample(0.4);
 
 		expect(true).toBe(true);
+	});
+
+	/**
+	 * Regression test for https://github.com/motiondivision/motion/issues/3133
+	 *
+	 * teardown() nulls startTime when an animation finishes, so replaying it
+	 * used to rebuild startTime from the (stale) creation time and the animation
+	 * would immediately finish again.
+	 */
+	test('.play() replays a finished animation once the clock has moved on', async () => {
+		const driver = persistentSyncDriver(20);
+		const output: number[] = [];
+
+		const animation = animateValue({
+			keyframes: [0, 100],
+			duration: 100,
+			ease: 'linear',
+			onUpdate: (v) => output.push(Math.round(v)),
+			driver,
+		});
+
+		await nextFrame();
+
+		expect(output).toEqual([0, 20, 40, 60, 80, 100]);
+
+		animation.play();
+
+		await nextFrame();
+
+		expect(output).toEqual([0, 20, 40, 60, 80, 100, 0, 20, 40, 60, 80, 100]);
+	});
+
+	/**
+	 * Regression test for https://github.com/motiondivision/motion/issues/2947
+	 */
+	test('.play() with speed -1 replays a finished animation in reverse', async () => {
+		const driver = persistentSyncDriver(20);
+		const output: number[] = [];
+
+		const animation = animateValue({
+			keyframes: [0, 100],
+			duration: 100,
+			ease: 'linear',
+			onUpdate: (v) => output.push(Math.round(v)),
+			driver,
+		});
+
+		await nextFrame();
+
+		output.length = 0;
+
+		animation.speed = -1;
+		animation.play();
+
+		await nextFrame();
+
+		expect(output).toEqual([100, 80, 60, 40, 20, 0]);
 	});
 });

--- a/packages/motion-start/src/animation/animators/__tests__/utils.ts
+++ b/packages/motion-start/src/animation/animators/__tests__/utils.ts
@@ -50,6 +50,53 @@ export const syncDriver = (interval = 10) => {
 	return driver;
 };
 
+/**
+ * A sync driver whose clock persists across driver instances, mimicking the
+ * real frameloop driver where time keeps advancing after an animation has
+ * finished and its driver has been torn down.
+ */
+export const persistentSyncDriver = (interval = 10) => {
+	let elapsed = 0;
+	time.set(elapsed);
+
+	const driver = (update: (v: number) => void) => {
+		let isRunning = true;
+		let pendingUpdate: ReturnType<typeof setTimeout> | undefined;
+
+		frameData.isProcessing = true;
+		frameData.delta = interval;
+		frameData.timestamp = elapsed;
+
+		return {
+			start: () => {
+				isRunning = true;
+				pendingUpdate = setTimeout(() => {
+					pendingUpdate = undefined;
+					if (!isRunning) return;
+					time.set(elapsed);
+					update(elapsed);
+					while (isRunning) {
+						elapsed += interval;
+						time.set(elapsed);
+						update(elapsed);
+					}
+				}, 0);
+			},
+			stop: () => {
+				frameData.isProcessing = false;
+				isRunning = false;
+				if (pendingUpdate !== undefined) {
+					clearTimeout(pendingUpdate);
+					pendingUpdate = undefined;
+				}
+			},
+			now: () => elapsed,
+		};
+	};
+
+	return driver;
+};
+
 export function animateSync(animation: KeyframeGenerator<string | number>, timeStep = 200, round = true) {
 	const output: Array<string | number> = [];
 	let step = 0;

--- a/packages/motion-start/src/animation/animators/waapi/NativeAnimation.ts
+++ b/packages/motion-start/src/animation/animators/waapi/NativeAnimation.ts
@@ -119,7 +119,11 @@ export class NativeAnimation implements AnimationPlaybackControls {
 		this.removeAnimation = () => state.get(element)?.delete(valueName);
 
 		const onFinish = () => {
-			this.setValue(element as HTMLElement, valueName, getFinalKeyframe(valueKeyframes as string[], this.options));
+			this.setValue(
+				element as HTMLElement,
+				valueName,
+				getFinalKeyframe(valueKeyframes as string[], this.options, undefined, this.speed)
+			);
 			this.cancel();
 			this.resolveFinishedPromise();
 		};

--- a/packages/motion-start/src/animation/animators/waapi/utils/__tests__/get-final-keyframes.spec.ts
+++ b/packages/motion-start/src/animation/animators/waapi/utils/__tests__/get-final-keyframes.spec.ts
@@ -14,4 +14,17 @@ describe('getFinalKeyframe', () => {
 		expect(getFinalKeyframe([0, 1], { repeat: 1, repeatType: 'mirror' })).toEqual(0);
 		expect(getFinalKeyframe([0, 1], { repeat: 2, repeatType: 'mirror' })).toEqual(1);
 	});
+
+	test('returns the first keyframe when playing in reverse', () => {
+		expect(getFinalKeyframe([0, 1], {}, undefined, -1)).toEqual(0);
+		expect(getFinalKeyframe([0, 1], {}, 2, -1)).toEqual(0);
+		expect(getFinalKeyframe([0, 1], { repeat: 1, repeatType: 'reverse' }, undefined, -1)).toEqual(0);
+		expect(getFinalKeyframe([0, 1], { repeat: 2, repeatType: 'reverse' }, undefined, -1)).toEqual(0);
+	});
+
+	test('returns the final keyframe for positive speeds', () => {
+		expect(getFinalKeyframe([0, 1], {}, undefined, 1)).toEqual(1);
+		expect(getFinalKeyframe([0, 1], {}, undefined, 2)).toEqual(1);
+		expect(getFinalKeyframe([0, 1], {}, 2, 2)).toEqual(2);
+	});
 });

--- a/packages/motion-start/src/animation/animators/waapi/utils/get-final-keyframe.ts
+++ b/packages/motion-start/src/animation/animators/waapi/utils/get-final-keyframe.ts
@@ -7,9 +7,20 @@ import type { Repeat } from '../../../../types.js';
 
 const isNotNull = (value: unknown) => value !== null;
 
-export function getFinalKeyframe<T>(keyframes: T[], { repeat, repeatType = 'loop' }: Repeat, finalKeyframe?: T): T {
+export function getFinalKeyframe<T>(
+	keyframes: T[],
+	{ repeat, repeatType = 'loop' }: Repeat,
+	finalKeyframe?: T,
+	speed = 1
+): T {
 	const resolvedKeyframes = keyframes.filter(isNotNull);
-	const index = repeat && repeatType !== 'loop' && repeat % 2 === 1 ? 0 : resolvedKeyframes.length - 1;
+
+	/**
+	 * When playing in reverse the animation ends on its first keyframe, as do
+	 * animations that finish on an odd iteration of a non-looping repeat.
+	 */
+	const useFirstKeyframe = speed < 0 || (repeat && repeatType !== 'loop' && repeat % 2 === 1);
+	const index = useFirstKeyframe ? 0 : resolvedKeyframes.length - 1;
 
 	return !index || finalKeyframe === undefined ? resolvedKeyframes[index] : finalKeyframe;
 }


### PR DESCRIPTION
Ports three targeted behavioural fixes from upstream Motion (originally landed as part of the large "Animation refactor" in motiondivision/motion#3148) **without** the architectural rewrite. Upstream issues: [#3133](https://github.com/motiondivision/motion/issues/3133), [#2947](https://github.com/motiondivision/motion/issues/2947), [#3113](https://github.com/motiondivision/motion/issues/3113).

The three fixes interlock through `getFinalKeyframe`, so they are delivered together.

## #3133 — a finished `MainThreadAnimation` could not be replayed

`teardown()` nulls `startTime` when an animation finishes, so on `play()` the `!this.startTime` branch fired *first* and rebuilt `startTime` from the original, now-stale `createdAt`. The animation was therefore instantly "already finished" again, and the `state === 'finished'` branch was unreachable.

`play()` now checks the finished state first (matching upstream `JSAnimation.play()`), rebasing `startTime` on the driver's current time.

## #2947 — `speed: -1` did not play in reverse

* `getFinalKeyframe` gained a `speed` parameter and selects the **first** keyframe when `speed < 0`.
* `play()` offsets `startTime` by `calculatedDuration` when replaying a finished animation in reverse.
* The `speed` setter now brings `currentTime` up to date (`updateTime(time.now())`) before the new speed is applied, so elapsed time isn't rebased at the new speed. The current-time calculation was extracted from `tick()` into a private `updateTime()` for this.

## #3113 — non-default `speed` committed the wrong terminal keyframe

Accelerated values such as `opacity` run on WAAPI, and the WAAPI `onfinish` handlers committed `getFinalKeyframe(...)` without a speed, so a reversed or sped-up animation snapped to the wrong end. Speed is now threaded through both `AcceleratedAnimation` and the mini `NativeAnimation` path.

Note: upstream additionally clears `finishedTime` when speed goes negative (`NativeAnimation.ts`). This port has no `finishedTime` field — its `state` reads `animation.playState` directly — so there is no equivalent to port; introducing one belongs with the architectural rewrite.

## Tests

* `MainThreadAnimation`: replaying a finished animation once the clock has moved on, and replaying it in reverse with `speed = -1`. Both use a new `persistentSyncDriver` test helper whose clock survives driver teardown, mirroring the real frameloop driver (the existing `syncDriver` resets to 0 on every driver instance, which masked the bug).
* `getFinalKeyframe`: first keyframe for negative speeds, final keyframe for positive speeds.
* `AcceleratedAnimation`: a WAAPI animation finishing in reverse commits the first keyframe; finishing at `speed = 2` still commits the final keyframe.

All four new tests fail on `main` and pass with this change. Full suite: `bun run test:run` — the only failures are pre-existing timeouts (`package-imports`, `reorder-production-ssr`) that pass in isolation on this machine and are unrelated to these changes.

No architectural refactor, no unrelated changes.