### PR TITLE
fix(layout): resolve LayoutGroup id at init and stop swallowing context errors

### DIFF
--- a/.changeset/slimy-hoops-repair.md
+++ b/.changeset/slimy-hoops-repair.md
@@ -1,0 +1,19 @@
+---
+"motion-start": patch
+---
+
+Harden `LayoutGroup` id resolution for `motion` components.
+
+- `motion` components now resolve their enclosing `LayoutGroup` id once, during component
+  initialisation, instead of re-entering `getContext` from inside the `$derived` that builds
+  their props. `getContext` is an initialisation-only API, so keeping it out of a value that
+  recomputes on every props change removes the risk of the `LayoutGroup` prefix silently
+  disappearing from `layoutId` and breaking shared-layout animations.
+- `useLayoutGroupContext` no longer wraps its context read in a blanket `try`/`catch`. A
+  missing `LayoutGroup` provider is an expected `null` and is now detected with `hasContext`;
+  every other failure, including calling it outside component initialisation, throws
+  instead of quietly degrading.
+- Removed the unused, never-imported `createLayoutGroupContext` rune store and its
+  `LayoutGroupContextType` interface.
+- Internal: `useLayoutId(props)` is replaced by the pure helper
+  `getLayoutId(props, layoutGroupId)`.

--- a/packages/motion-start/src/components/LayoutGroup/__tests__/LayoutGroupMotionFixture.svelte
+++ b/packages/motion-start/src/components/LayoutGroup/__tests__/LayoutGroupMotionFixture.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import { motion } from '../../../index.js';
+import LayoutGroup from '../LayoutGroup.svelte';
+
+let width = $state(100);
+</script>
+
+<button id="resize-grouped-target" onclick={() => (width = 200)}>resize</button>
+
+<LayoutGroup id="group">
+	<motion.div
+		id="grouped-layout-target"
+		layout
+		layoutId="box"
+		style={{
+			width: `${width}px`,
+			height: '100px',
+		}}
+	/>
+</LayoutGroup>

--- a/packages/motion-start/src/components/LayoutGroup/__tests__/layout-group-motion.svelte.spec.ts
+++ b/packages/motion-start/src/components/LayoutGroup/__tests__/layout-group-motion.svelte.spec.ts
@@ -1,0 +1,38 @@
+import { flushSync, mount, unmount } from 'svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import { visualElementStore } from '../../../render/store.js';
+import { nextFrame } from '../../../test-utils/component-test-utils.js';
+import LayoutGroupMotionFixture from './LayoutGroupMotionFixture.svelte';
+
+let instance: ReturnType<typeof mount> | undefined;
+
+afterEach(async () => {
+	if (instance) await unmount(instance);
+	instance = undefined;
+	document.body.innerHTML = '';
+});
+
+describe('motion layoutId inside a LayoutGroup', () => {
+	it('keeps the LayoutGroup prefix across prop changes', async () => {
+		instance = mount(LayoutGroupMotionFixture, { target: document.body });
+		flushSync();
+		await nextFrame();
+
+		const target = document.querySelector('#grouped-layout-target') as HTMLElement;
+		const visualElement = visualElementStore.get(target);
+		expect(visualElement?.getProps().layoutId).toBe('group-box');
+
+		(document.querySelector('#resize-grouped-target') as HTMLButtonElement).click();
+		flushSync();
+		await nextFrame();
+
+		// Guard: the props recompute the regression depends on actually happened.
+		expect(visualElement?.getProps().style?.width).toBe('200px');
+
+		// The layout group id must survive a props recompute. Reading it from a
+		// `getContext` call inside a `$derived` silently degrades to the
+		// unprefixed id after the first evaluation.
+		expect(visualElement?.getProps().layoutId).toBe('group-box');
+		expect(visualElement?.projection?.options.layoutId).toBe('group-box');
+	});
+});

--- a/packages/motion-start/src/components/LayoutGroup/__tests__/layout-group.svelte.spec.ts
+++ b/packages/motion-start/src/components/LayoutGroup/__tests__/layout-group.svelte.spec.ts
@@ -1,5 +1,7 @@
 import { flushSync, mount, unmount } from 'svelte';
 import { afterEach, describe, expect, it } from 'vitest';
+import { useLayoutGroupContext } from '../../../context/LayoutGroupContext.svelte.js';
+import LayoutGroupConsumer from './LayoutGroupConsumer.svelte';
 import LayoutGroupFixture from './LayoutGroupFixture.svelte';
 
 let instance: ReturnType<typeof mount> | undefined;
@@ -37,5 +39,19 @@ describe('LayoutGroup context ownership', () => {
 		instance = mount(LayoutGroupFixture, { target: document.body });
 		flushSync();
 		expect(content('nested-after-undefined')).toBe('a-b');
+	});
+});
+
+describe('useLayoutGroupContext', () => {
+	it('reports a missing provider as null rather than throwing', () => {
+		instance = mount(LayoutGroupConsumer, { target: document.body, props: { id: 'no-provider' } });
+		flushSync();
+		expect(content('no-provider')).toBe('');
+	});
+
+	it('throws when read outside component initialisation', () => {
+		// A blanket try/catch here would turn this misuse into a silently
+		// unprefixed `layoutId`, so it has to stay loud.
+		expect(() => useLayoutGroupContext()).toThrow();
 	});
 });

--- a/packages/motion-start/src/context/LayoutGroupContext.svelte.ts
+++ b/packages/motion-start/src/context/LayoutGroupContext.svelte.ts
@@ -3,7 +3,7 @@ based on framer-motion@11.11.11,
 Copyright (c) 2018 Framer B.V.
 */
 
-import { createContext } from 'svelte';
+import { getContext, hasContext, setContext } from 'svelte';
 import type { NodeGroup } from '../projection/node/group.js';
 
 export interface LayoutGroupContext {
@@ -13,77 +13,25 @@ export interface LayoutGroupContext {
 	key?: number;
 }
 
-/**
- * Reactive layout group context using Svelte 5 runes
- */
-export interface LayoutGroupContextType {
-	// Reactive state (direct access)
-	dimensions: Map<string, DOMRect>;
-	isAnimating: boolean;
-	layoutChanged: boolean;
-
-	// Methods
-	registerElement: (id: string, rect: DOMRect) => void;
-	unregisterElement: (id: string) => void;
-	startAnimation: () => void;
-	finishAnimation: () => void;
-}
-
-/**
- * Create a reactive layout group context with $state and $derived runes.
- * Must be called within a component or .svelte.ts file.
- */
-export function createLayoutGroupContext(): LayoutGroupContextType {
-	let dimensions = $state<Map<string, DOMRect>>(new Map());
-	let animationCount = $state<number>(0);
-
-	// Derived state
-	let isAnimating = $derived(animationCount > 0);
-	let layoutChanged = $derived(dimensions.size > 0);
-
-	return {
-		get dimensions() {
-			return dimensions;
-		},
-		get isAnimating() {
-			return isAnimating;
-		},
-		get layoutChanged() {
-			return layoutChanged;
-		},
-
-		registerElement: (id: string, rect: DOMRect) => {
-			// Create new Map to trigger reactivity
-			dimensions = new Map(dimensions).set(id, rect);
-		},
-
-		unregisterElement: (id: string) => {
-			const newDimensions = new Map(dimensions);
-			newDimensions.delete(id);
-			dimensions = newDimensions;
-		},
-
-		startAnimation: () => {
-			animationCount++;
-		},
-
-		finishAnimation: () => {
-			animationCount = Math.max(0, animationCount - 1);
-		},
-	};
-}
-
 // Context key
 export const LAYOUT_GROUP_CONTEXT_KEY = Symbol('LayoutGroupContext');
 
-const [getLayoutGroupContext, setLayoutGroupContext] = createContext<LayoutGroupContext | null>();
+/**
+ * Reads the closest `LayoutGroup` context.
+ *
+ * `getContext`/`hasContext` are lifecycle APIs, so this must be called during
+ * component initialisation. A missing provider is expected, since motion
+ * components are routinely rendered outside a `LayoutGroup`, and is reported as
+ * `null`. Any other failure, notably calling this outside initialisation, is
+ * left to throw so the misuse is visible instead of silently degrading.
+ */
+function useLayoutGroupContext(): LayoutGroupContext | null {
+	if (!hasContext(LAYOUT_GROUP_CONTEXT_KEY)) return null;
+	return getContext<LayoutGroupContext | null>(LAYOUT_GROUP_CONTEXT_KEY) ?? null;
+}
 
-function useLayoutGroupContext() {
-	try {
-		return getLayoutGroupContext();
-	} catch {
-		return null;
-	}
+function setLayoutGroupContext(context: LayoutGroupContext): LayoutGroupContext {
+	return setContext(LAYOUT_GROUP_CONTEXT_KEY, context);
 }
 
 export { useLayoutGroupContext, setLayoutGroupContext };

--- a/packages/motion-start/src/context/index.svelte.ts
+++ b/packages/motion-start/src/context/index.svelte.ts
@@ -5,8 +5,4 @@ export {
 	defaultMotionConfig,
 	MOTION_CONFIG_CONTEXT_KEY,
 } from './MotionConfigContext.svelte.js';
-export {
-	createLayoutGroupContext,
-	type LayoutGroupContextType,
-	LAYOUT_GROUP_CONTEXT_KEY,
-} from './LayoutGroupContext.svelte.js';
+export { LAYOUT_GROUP_CONTEXT_KEY } from './LayoutGroupContext.svelte.js';

--- a/packages/motion-start/src/motion/index.svelte.ts
+++ b/packages/motion-start/src/motion/index.svelte.ts
@@ -78,11 +78,18 @@ export const createRendererMotionComponent = <Props extends {}, Instance, Render
 			};
 		});
 		const motionConfig = $derived.by(useMotionConfigContext);
+		/**
+		 * `LayoutGroup` is read through `getContext`, which is a component
+		 * initialisation API. Resolving the group id once here keeps the lookup
+		 * out of the derived below, so a props recompute can never re-enter the
+		 * context system and drop the prefix from `layoutId`.
+		 */
+		const layoutGroupId = useLayoutGroupContext()?.id;
 		const configAndProps = $derived.by(() => {
 			const propsState = $state({
 				...motionConfig,
 				...motionProps,
-				layoutId: useLayoutId(() => motionProps),
+				layoutId: getLayoutId(motionProps, layoutGroupId),
 			});
 			return propsState;
 		});
@@ -213,10 +220,13 @@ export const createRendererMotionComponent = <Props extends {}, Instance, Render
 	return MotionComponent;
 };
 
-export function useLayoutId(props: () => MotionProps) {
-	const { layoutId } = props();
-	const { id: layoutGroupId } = useLayoutGroupContext() ?? {};
-
+/**
+ * Prefixes `layoutId` with the enclosing `LayoutGroup` id.
+ *
+ * `layoutGroupId` must be resolved during component initialisation; this helper
+ * is pure so it can safely run inside a `$derived`.
+ */
+export function getLayoutId({ layoutId }: MotionProps, layoutGroupId?: string) {
 	return layoutGroupId && layoutId !== undefined ? `${layoutGroupId}-${layoutId}` : layoutId;
 }
 


### PR DESCRIPTION
## The problem

`packages/motion-start/src/motion/index.svelte.ts` assembled `configAndProps` like this:

```ts
const configAndProps = $derived.by(() => {
	const propsState = $state({
		...motionConfig,
		...motionProps,
		layoutId: useLayoutId(() => motionProps),
	});
	return propsState;
});
```

`useLayoutId` calls `useLayoutGroupContext()`, which reaches into Svelte's context system. `getContext`/`hasContext` are **component-initialisation** APIs — they throw `lifecycle_outside_component` whenever `component_context` is null. Putting one inside a value that recomputes on every props change means the context lookup is re-entered long after initialisation, from whatever call site happens to pull on the derived.

That was made invisible by a blanket catch in `packages/motion-start/src/context/LayoutGroupContext.svelte.ts`:

```ts
function useLayoutGroupContext() {
	try {
		return getLayoutGroupContext();
	} catch {
		return null;
	}
}
```

The catch existed for a legitimate reason — motion elements are routinely rendered with no `LayoutGroup` ancestor, and `createContext`'s getter throws `missing_context` in that case. But it caught *everything*, so a lifecycle violation was indistinguishable from "no provider" and degraded to `layoutGroupId === undefined`. The observable symptom would be `layoutId` losing its `LayoutGroup` prefix after a prop change, which silently breaks shared-layout animations between grouped elements.

### Honest scoping note

I wrote the regression test first and it **passed against the unfixed code**. Digging into `svelte@5.56.8`, `update_reaction` restores the reaction's captured component context before recomputing (`set_component_context(reaction.ctx)` in `internal/client/runtime.js`), and `$derived` signals capture `ctx: component_context` at creation (`internal/client/reactivity/deriveds.js`). Because `renderMotionComponent` runs inside `MotionScope`'s initialisation, the derived captures a non-null ctx and `getContext` still resolves on recompute. So on this Svelte version the prefix does not actually drop today.

What remains real, and is what this PR fixes:

- The call is still an initialisation-only API invoked from a recomputing derived. It only works by virtue of a Svelte implementation detail about ctx restoration, and it breaks the moment the value is pulled from outside a reaction (a `tick().then()`, a rAF callback, a microtask render) or the derived is created without a component context.
- The blanket `catch` genuinely does erase that failure mode. That is the part that made the hazard undiagnosable, and it is removed.
- The redundant per-recompute context lookup is now done once.

I've left the reproduction test in as a regression guard rather than deleting it, and added a direct test that the context helper throws outside initialisation.

## The fix

- **Resolve once at init.** `const layoutGroupId = useLayoutGroupContext()?.id;` now sits in the component body, outside any `$derived`. The derived reads the already-resolved value.
- **`useLayoutId` → `getLayoutId`.** The old `use*` hook was the footgun; it's replaced by a pure `getLayoutId(props, layoutGroupId)` that is safe to call from a derived. Nothing else in the repo referenced `useLayoutId`.
- **No more blanket catch.** `useLayoutGroupContext` now uses an explicit `hasContext` check for the documented "no provider" case and lets everything else throw. I checked all four call sites first:
  - `LayoutGroup.svelte` — `useLayoutGroupContext() || { id: oldId }`, legitimately runs with no provider at the root of a group. Covered by `hasContext`.
  - `MeasureLayout.svelte` — `?? { forceRender: () => {} }`, same.
  - `motion/index.svelte.ts` — now init-only.
  - `LayoutGroupConsumer.svelte` (test fixture) — now has explicit coverage for the no-provider case.
- **Dead code removed.** `createLayoutGroupContext` and `LayoutGroupContextType` (the rune-store implementation) had no importers anywhere in the repo — only doc/plan files mention them. Deleted, along with their re-export from the `src/context` barrel. The barrel isn't in `package.json#exports` and isn't imported anywhere, so this isn't a public API break.

I kept the `.svelte.ts` extension on `LayoutGroupContext.svelte.ts` even though it no longer contains runes, because `src/index.ts` re-exports the `LayoutGroupContext` type from that path.

## Tests

- `layout-group-motion.svelte.spec.ts` (new): mounts `motion.div` with `layoutId="box"` inside `<LayoutGroup id="group">`, changes a style prop, and asserts both `visualElement.getProps().layoutId` and `projection.options.layoutId` are still `group-box`. It asserts the props recompute actually happened (`style.width === '200px'`) so it can't pass vacuously.
- `layout-group.svelte.spec.ts`: added coverage that `useLayoutGroupContext()` returns `null` with no provider and **throws** when called outside component initialisation.

## Verification

- `bun run test:run` — 620 passed, 1 skipped. The single failure (`package-imports.spec.ts` "fully specifies relative JavaScript imports") is a 5s-timeout flake on this machine and **reproduces identically on a clean `git stash`ed tree**; it's unrelated to this change.
- `bun run check` (svelte-check) — 0 errors, 0 warnings.
- `biome lint` on the touched files — no new diagnostics (remaining ones are pre-existing `noExplicitAny`/CRLF noise shared with `main`).

## Follow-up, not done here

`use-visual-element.svelte.ts` has the same shape — `$derived(useSwitchLayoutGroupContext())` — and `SwitchLayoutGroupContext.ts` / `DeprecatedLayoutGroupContext.ts` both still use blanket `try`/`catch`. Left alone deliberately to keep this PR scoped; worth folding into the planned context refactor.