### PR TITLE
Export `HTMLMotionProps` from the package root

### DIFF
--- a/.changeset/tidy-pugs-export.md
+++ b/.changeset/tidy-pugs-export.md
@@ -1,0 +1,14 @@
+---
+'motion-start': patch
+---
+
+Export the `HTMLMotionProps` type from the package root.
+
+`HTMLMotionProps<Tag>` is the props type behind every `motion.*` HTML component and is part of
+framer-motion's public API, but it was declared in `render/html/types.ts` without being re-exported
+from any entry point. Consumers writing wrapper components around `motion.div`, `motion.button` and
+friends had no way to name the props they were forwarding.
+
+The root entry now re-exports it alongside `ForwardRefComponent`, matching upstream. A type-level
+test imports it from the public entry the way a consumer would, so the export cannot silently
+regress.

--- a/packages/motion-start/src/index.spec-d.ts
+++ b/packages/motion-start/src/index.spec-d.ts
@@ -1,0 +1,14 @@
+import type { HTMLMotionProps } from './index.js';
+
+describe('public entry type surface', () => {
+	it('exports HTMLMotionProps so consumers can type wrapper components', () => {
+		type ButtonWrapperProps = HTMLMotionProps<'button'> & { label: string };
+
+		assertType<ButtonWrapperProps>({
+			label: 'Save',
+			type: 'submit',
+			animate: { opacity: 1 },
+			whileHover: { scale: 1.1 },
+		});
+	});
+});

--- a/packages/motion-start/src/index.ts
+++ b/packages/motion-start/src/index.ts
@@ -147,7 +147,7 @@ export type {
 export * from './projection/geometry/types.js';
 export type { IProjectionNode } from './projection/node/types.js';
 export type { DOMMotionComponents } from './render/dom/types.js';
-export type { ForwardRefComponent } from './render/html/types.js';
+export type { ForwardRefComponent, HTMLMotionProps } from './render/html/types.js';
 export type { SVGAttributesAsMotionValues, SVGMotionProps } from './render/svg/types.js';
 export type { AnimationLifecycles, CreateVisualElement } from './render/types.js';
 export { FlatTree } from './render/utils/flat-tree.js';


### PR DESCRIPTION
## The gap

`HTMLMotionProps<Tag>` is declared in `packages/motion-start/src/render/html/types.ts` (marked `@public`) and is the props type behind every `motion.*` HTML component — but it was not re-exported from any entry point. Line 150 of `src/index.ts` re-exported only `ForwardRefComponent` from that module, so the type sat next to a public export without being one.

Confirmed against every entry declared in `packages/motion-start/package.json` `exports` (`.`, `./dom`, `./dom/mini`, `./client`, `./m`, `./mini`, `./projection`, and the three `./src/*` subpaths) and against the built `.d.ts` output — `dist/index.d.ts` contained `export type { ForwardRefComponent } from './render/html/types.js';` and nothing else pointing at that module.

Verified from a real consumer's perspective, not just in source: I built the package and compiled a throwaway project whose `node_modules/motion-start` pointed at the built package, resolving through the published `types` condition.

- Before the fix: `error TS2724: '"motion-start"' has no exported member named 'HTMLMotionProps'. Did you mean 'MotionProps'?`
- After the fix: compiles cleanly.

## The change

```diff
-export type { ForwardRefComponent } from './render/html/types.js';
+export type { ForwardRefComponent, HTMLMotionProps } from './render/html/types.js';
```

This matches upstream framer-motion v11.11.11, which exports exactly `{ HTMLMotionProps, ForwardRefComponent }` from `./render/html/types`, and matches how the sibling SVG types are already exported on the next line.

## Audit of the other prop/type definitions

I diffed the public type surface of `render/html/types.ts`, `render/svg/types.ts` and `motion/types.ts` against upstream's `index.ts`. **`HTMLMotionProps` was the only genuine gap** — nothing else needed adding:

| Type | Status |
| --- | --- |
| `ForwardRefComponent` | already exported |
| `SVGMotionProps`, `SVGAttributesAsMotionValues` | already exported |
| `MotionProps`, `AnimationProps`, `MotionAdvancedProps`, `MotionStyle`, `MotionTransform`, `VariantLabels` | already exported (identical set to upstream) |
| `DOMMotionComponents` | already exported |

Types I deliberately did **not** export, despite `@public` doc comments on some of them:

- `HTMLMotionComponents` / `SVGMotionComponents` — upstream does not export these by name either; they are reachable structurally through the already-exported `DOMMotionComponents = HTMLMotionComponents & SVGMotionComponents`, which is what consumers actually use.
- `HTMLRenderState`, `TransformOrigin`, `SVGRenderState`, `SVGDimensions`, `UnwrapSVGFactoryElement` — renderer-internal state shapes, not part of upstream's public API.
- `MakeMotion`, `MotionCSS`, `MotionCSSVariables`, `TransformProperties`, `CustomStyles`, `SVGPathProperties`, `OnUpdate`, `AppearOptions`, `TransformTemplate` — building blocks of the public types rather than public types themselves; upstream keeps them internal too.

The goal here was to close a real consumer-facing hole, not to widen the API surface, so I kept it to the one type.

## Regression guard

Added `packages/motion-start/src/index.spec-d.ts`, following the repo's existing `*.spec-d.ts` type-test convention (`src/types.spec-d.ts`, `src/render/html/type.spec-d.ts`, etc.), which run under `vitest --typecheck`. It imports `HTMLMotionProps` from the public entry the way a consumer would and uses it to type a wrapper component's props, so removing the export fails the type test.

Added a changeset (`patch`) in the existing format.

## Verification

- `bun run build` — passes, `dist/index.d.ts` now exports `HTMLMotionProps`
- `bun run test:types` — 22 type test files pass, no type errors
- `bun run test:run` — 641 pass, "Type Errors: no errors". Three `Reorder production SSR` tests time out at 30s under full-suite load; they pass in isolation both with and without this change, so they are pre-existing flakiness unrelated to this type-only edit.
- `bun run check:package` (svelte-check) — 0 errors, 0 warnings
- Biome — clean on both touched/added files (`src/index.ts` has pre-existing whole-file formatting complaints on this checkout that are unchanged by this PR)

No unrelated changes.