### PR TITLE
Fix reactivity misuses in the motion component body

### DIFF
--- a/.changeset/smooth-jokes-repeat.md
+++ b/.changeset/smooth-jokes-repeat.md
@@ -1,0 +1,16 @@
+---
+"motion-start": patch
+---
+
+Fix two reactivity misuses in the motion component body.
+
+- The merged config/props object was built with `$state` inside a `$derived`. The derived
+  already recomputes on dependency changes, so the inner `$state` added no reactivity — it
+  only allocated a fresh deep proxy over the whole props graph (`style`, `variants`,
+  `animate`, ...) on every recomputation. That churned the identity of structures
+  `VisualElement` holds by reference and made user objects reactive that never asked to be.
+  It is now a plain object.
+- The visual element was assigned onto the object a `$derived` owns. Any variant or tracked
+  prop change rebuilt that object, so `context.visualElement` momentarily read as
+  `undefined` — dropping the element's listeners and measure props for that window. It now
+  lives in init-time state that the context reads through a getter.

--- a/packages/motion-start/src/motion/__tests__/ReactivityFixture.svelte
+++ b/packages/motion-start/src/motion/__tests__/ReactivityFixture.svelte
@@ -1,0 +1,13 @@
+<svelte:options runes={true} />
+
+<script lang="ts">
+import { ProbeMotion, probeStyle, probeVariants } from './probe-motion-component.svelte.js';
+
+let variant = $state('visible');
+</script>
+
+<button id="change-variant" onclick={() => (variant = variant === "visible" ? "hidden" : "visible")}
+	>change variant</button
+>
+
+<ProbeMotion animate={variant} variants={probeVariants} style={probeStyle} />

--- a/packages/motion-start/src/motion/__tests__/probe-motion-component.svelte.ts
+++ b/packages/motion-start/src/motion/__tests__/probe-motion-component.svelte.ts
@@ -1,0 +1,88 @@
+import type { CreateVisualElement } from '../../render/types.js';
+import type { VisualElement } from '../../render/VisualElement.svelte.js';
+import { createRendererMotionComponent } from '../index.svelte.js';
+import type { MotionProps } from '../types.js';
+import { makeUseVisualState } from '../utils/use-visual-state.svelte.js';
+
+/**
+ * A motion component built on the real `createRendererMotionComponent` with a
+ * stubbed renderer and visual element, so the reactive wiring of the motion body
+ * can be observed without depending on the DOM feature bundle.
+ */
+
+/** Nested prop objects the fixture passes by reference, for identity assertions. */
+export const probeStyle = { opacity: 1 };
+export const probeVariants = {
+	visible: { x: 0 },
+	hidden: { x: 100 },
+};
+
+export interface ProbeRecord {
+	createProps: MotionProps | null;
+	updateProps: MotionProps[];
+	renderProps: {
+		props: MotionProps;
+		visualElement?: VisualElement<HTMLElement>;
+	} | null;
+	visualElement: VisualElement<HTMLElement> | null;
+}
+
+export const probe: ProbeRecord = {
+	createProps: null,
+	updateProps: [],
+	renderProps: null,
+	visualElement: null,
+};
+
+export function resetProbe() {
+	probe.createProps = null;
+	probe.updateProps = [];
+	probe.renderProps = null;
+	probe.visualElement = null;
+}
+
+const noop = () => undefined;
+
+const createVisualElement: CreateVisualElement<HTMLElement> = ((
+	_Component: unknown,
+	options: { props: MotionProps; visualState: { latestValues: Record<string, unknown> } }
+) => {
+	probe.createProps = options.props;
+
+	const element = {
+		type: 'probe',
+		props: options.props,
+		latestValues: options.visualState.latestValues,
+		listeners: {},
+		options: {},
+		presenceContext: null,
+		projection: undefined,
+		animationState: undefined,
+		update(props: MotionProps) {
+			element.props = props;
+			probe.updateProps.push(props);
+		},
+		updateFeatures: noop,
+		render: noop,
+		mount: noop,
+		unmount: noop,
+	};
+
+	probe.visualElement = element as unknown as VisualElement<HTMLElement>;
+	return probe.visualElement;
+}) as unknown as CreateVisualElement<HTMLElement>;
+
+const useVisualState = makeUseVisualState<HTMLElement, Record<string, unknown>>({
+	scrapeMotionValuesFromProps: () => ({}),
+	createRenderState: () => ({}),
+});
+
+export const ProbeMotion = createRendererMotionComponent<MotionProps, HTMLElement, Record<string, unknown>>({
+	createVisualElement,
+	useVisualState,
+	useRender: ((_anchor: unknown, props: ProbeRecord['renderProps']) => {
+		probe.renderProps = props;
+		return null;
+	}) as never,
+	Component: 'div',
+});

--- a/packages/motion-start/src/motion/__tests__/reactivity.svelte.spec.ts
+++ b/packages/motion-start/src/motion/__tests__/reactivity.svelte.spec.ts
@@ -1,0 +1,61 @@
+import { flushSync, mount, unmount } from 'svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import ReactivityFixture from './ReactivityFixture.svelte';
+import { probe, probeStyle, probeVariants, resetProbe } from './probe-motion-component.svelte.js';
+
+let instance: ReturnType<typeof mount> | undefined;
+
+function changeVariant() {
+	(document.querySelector('#change-variant') as HTMLButtonElement).click();
+}
+
+afterEach(async () => {
+	if (instance) await unmount(instance);
+	instance = undefined;
+	resetProbe();
+	document.body.innerHTML = '';
+});
+
+describe('motion component reactivity', () => {
+	it('passes nested prop objects through by reference instead of deep proxying them', () => {
+		instance = mount(ReactivityFixture, { target: document.body });
+		flushSync();
+
+		expect(probe.createProps).not.toBeNull();
+		expect(probe.createProps?.style).toBe(probeStyle);
+		expect(probe.createProps?.variants).toBe(probeVariants);
+	});
+
+	it('keeps nested prop identity stable across recomputations', () => {
+		instance = mount(ReactivityFixture, { target: document.body });
+		flushSync();
+
+		changeVariant();
+		flushSync();
+
+		const latest = probe.updateProps.at(-1);
+		expect(latest).toBeDefined();
+		expect(latest?.animate).toBe('hidden');
+		expect(latest?.style).toBe(probeStyle);
+		expect(latest?.variants).toBe(probeVariants);
+		expect(latest?.style).toBe(probe.createProps?.style);
+		expect(latest?.variants).toBe(probe.createProps?.variants);
+	});
+
+	it('keeps the context visual element defined across a variant change', () => {
+		instance = mount(ReactivityFixture, { target: document.body });
+		flushSync();
+
+		const mounted = probe.renderProps?.visualElement;
+		expect(mounted).toBeDefined();
+
+		changeVariant();
+
+		// Read before the commit flushes: the context must not drop its visual
+		// element while the derived tree-variant object is rebuilt.
+		expect(probe.renderProps?.visualElement).toBe(mounted);
+
+		flushSync();
+		expect(probe.renderProps?.visualElement).toBe(mounted);
+	});
+});

--- a/packages/motion-start/src/motion/index.svelte.ts
+++ b/packages/motion-start/src/motion/index.svelte.ts
@@ -10,8 +10,9 @@ import { useLayoutGroupContext } from '../context/LayoutGroupContext.svelte.js';
 import { useLazyContext } from '../context/LazyContext.js';
 import { useMotionConfigContext } from '../context/MotionConfigContext.svelte.js';
 import { useCreateMotionContext } from '../context/MotionContext/create.svelte.js';
-import { setMotionContext, useMotionContext } from '../context/MotionContext/index.js';
+import { setMotionContext, type MotionContext, useMotionContext } from '../context/MotionContext/index.js';
 import type { CreateVisualElement } from '../render/types.js';
+import type { VisualElement } from '../render/VisualElement.svelte.js';
 import { invariant, warning } from '../utils/errors.js';
 import type { Ref } from '../utils/safe-react-types.js';
 import { featureDefinitions } from './features/definitions.js';
@@ -78,20 +79,47 @@ export const createRendererMotionComponent = <Props extends {}, Instance, Render
 			};
 		});
 		const motionConfig = $derived.by(useMotionConfigContext);
-		const configAndProps = $derived.by(() => {
-			const propsState = $state({
-				...motionConfig,
-				...motionProps,
-				layoutId: useLayoutId(() => motionProps),
-			});
-			return propsState;
-		});
+		/**
+		 * A plain object: the `$derived` already recomputes when the config or props
+		 * change, so wrapping the result in `$state` adds no reactivity. It would only
+		 * deep-proxy the whole props graph (`style`, `variants`, `animate`, ...) on
+		 * every recomputation, changing the identity of structures `VisualElement`
+		 * holds by reference and making user objects reactive that never asked to be.
+		 */
+		const configAndProps = $derived.by(() => ({
+			...motionConfig,
+			...motionProps,
+			layoutId: useLayoutId(() => motionProps),
+		}));
 
 		const { isStatic } = $derived(configAndProps);
 
 		const parentContext = useMotionContext();
 
-		const context = $derived.by(useCreateMotionContext<Instance>(() => motionProps, parentContext));
+		const treeVariants = $derived.by(useCreateMotionContext<Instance>(() => motionProps, parentContext));
+
+		/**
+		 * The visual element lives in init-time state rather than on the object
+		 * `treeVariants` derives. Writing it onto the derived's result meant every
+		 * variant change rebuilt that object and dropped the visual element, so any
+		 * read between the rebuild and the reassignment below saw `undefined`.
+		 */
+		let contextVisualElement = $state<VisualElement<Instance> | null>(null);
+
+		const context: MotionContext<Instance> = {
+			get initial() {
+				return treeVariants.initial;
+			},
+			get animate() {
+				return treeVariants.animate;
+			},
+			get visualElement() {
+				return contextVisualElement;
+			},
+			set visualElement(value) {
+				contextVisualElement = value ?? null;
+			},
+		};
 
 		// Call useVisualState once — mirrors React's useConstant pattern.
 		// visualState.latestValues is taken by reference by VisualElement and mutated
@@ -138,15 +166,6 @@ export const createRendererMotionComponent = <Props extends {}, Instance, Render
 		watch.pre([() => visualElement], () => {
 			context.visualElement = visualElement;
 		});
-
-		// $effect(() => {
-		// 	// MotionContext.Provider
-		// 	MotionContext.Provider = context;
-		// 	return () => {
-		// 		// Since useMotionRef is not called on destroy, the visual element is unmounted here
-		// 		context.visualElement?.unmount();
-		// 	};
-		// });
 
 		let rendererInstance: Record<string, any> | null = null;
 


### PR DESCRIPTION
Two reactivity misuses in `createRendererMotionComponent` / `renderMotionComponent`, plus a dead comment block.

### 1. `$state({...})` created inside a `$derived.by`

`configAndProps` built its result with `$state`. The `$derived` already re-runs when `motionConfig` / `motionProps` change, so the inner `$state` bought nothing — it just allocated a fresh deep `Proxy` over the entire props graph (`style`, `variants`, `animate`, ...) on every recomputation. That:

- changes the identity of nested structures `VisualElement` holds by reference, and
- deep-proxies user objects that never asked to be reactive.

Nothing mutates the resulting object — `VisualElement` only ever replaces `this.props` wholesale in `update()` — so it is now a plain object literal.

### 2. `context.visualElement` mutated onto a derived-owned object

`useCreateMotionContext` returns a `$derived` object, and the watcher wrote `visualElement` onto it. Any variant or tracked prop change rebuilt that object, so `context.visualElement` read as `undefined` until the watcher ran again. In that window `UseRender` loses the element's `listeners` and `measureProps.visualElement` goes undefined.

The visual element now lives in init-time `$state`, and `context` is a stable object exposing `initial` / `animate` from the derived through getters and `visualElement` through a getter/setter pair. The existing `watch.pre` assignment is unchanged.

### 3. Dead code

The commented-out `$effect` block claimed "useMotionRef is not called on destroy" — it is: `UseRender`'s `motionRef` attachment teardown calls `ref(null)`, which unmounts the visual element. The note is stale, so the block is removed.

## Tests

`packages/motion-start/src/motion/__tests__/reactivity.svelte.spec.ts` drives the real `createRendererMotionComponent` with a stub renderer/visual element (`probe-motion-component.svelte.ts` + `ReactivityFixture.svelte`) and asserts:

- nested prop objects (`style`, `variants`) reach the visual element by reference rather than as proxy clones;
- that identity is stable across a recomputation triggered by a variant change;
- `context.visualElement` stays defined when read immediately after a variant change, before the commit flushes.

All three fail on `main` and pass with this change.

## Verification

- `vitest run` (package): 621 passed. Two pre-existing failures on this machine (`package-imports`, `reorder-production-ssr`) are 30s in-test timeouts on disk/build-heavy work and fail identically without this change.
- `svelte-check`: 0 errors, 0 warnings.
- `biome check` on the changed files: clean apart from the same Svelte-template false positives (`noUnusedVariables` for template-only bindings) that existing fixtures produce.

Scope note: `useLayoutId` inside the `$derived.by` and the broader `create-factory` / `create-proxy` / `use-render` / `MotionScope` restructure are deliberately untouched.