### PR TITLE
Backport seven upstream Motion bug fixes

### DIFF
--- a/.changeset/quiet-koalas-backport.md
+++ b/.changeset/quiet-koalas-backport.md
@@ -1,0 +1,32 @@
+---
+'motion-start': patch
+---
+
+Backport seven behavioural bug fixes from upstream Motion (this port is based on
+framer-motion 11.11.11).
+
+- **Reduced motion now blocks positional values, not just transforms** (upstream
+  11.16.6). `shouldReduceMotion` was gated on `transformProps`, so `height`, `width`,
+  `top`, `left` and friends still animated for users who asked for reduced motion. The
+  gate now uses `positionalKeys`.
+- **`width`/`height` unit conversion respects `box-sizing: border-box`** (upstream
+  12.36.0). Padding was always subtracted from the measured box, which made
+  `width`/`height: auto` animations start and end at the wrong size on border-box
+  elements.
+- **`calc()` divisors are no longer zeroed when building an animatable `none`**
+  (upstream 12.35.2). `complex.getAnimatableNone('calc(var(--gap) / 5)')` zeroed every
+  number it found, producing `calc(var(--gap) / 0)` and therefore `NaN`. Numbers directly
+  following a `/` are now preserved.
+- **`anticipate` easing is clamped at `p >= 1`** (upstream 12.36.0). It previously
+  overshot past `1` for progress values at or beyond the end of the animation.
+- **WAAPI `linear()` easing points are rounded to four decimal places** (upstream
+  12.17.0). Unrounded floats produced needlessly long easing strings with spurious
+  precision.
+- **Elements with a `transformTemplate` no longer take the WAAPI path** (upstream
+  11.18.2). `AcceleratedAnimation.supports()` did not check for `transformTemplate`, so a
+  hardware-accelerated animation would drop the user's custom transform ordering for its
+  duration.
+- **Time-defined springs ignore inherited velocity** (upstream 12.34.3). Velocity carried
+  over from an interrupted animation leaked into `findSpring()`, producing wildly
+  different spring parameters and massive oscillation on small-range `duration`/`bounce`
+  springs.

--- a/packages/motion-start/src/animation/animators/AcceleratedAnimation.ts
+++ b/packages/motion-start/src/animation/animators/AcceleratedAnimation.ts
@@ -439,6 +439,11 @@ export class AcceleratedAnimation<T extends string | number> extends BaseAnimati
 			 * no way to read the value from WAAPI every frame.
 			 */
 			!motionValue.owner.getProps().onUpdate &&
+			/**
+			 * WAAPI animations bypass the render pipeline, so an element with a
+			 * transformTemplate would lose it for the duration of the animation.
+			 */
+			!motionValue.owner.getProps().transformTemplate &&
 			!repeatDelay &&
 			repeatType !== 'mirror' &&
 			damping !== 0 &&

--- a/packages/motion-start/src/animation/animators/__tests__/AcceleratedAnimation.spec.ts
+++ b/packages/motion-start/src/animation/animators/__tests__/AcceleratedAnimation.spec.ts
@@ -69,4 +69,35 @@ describe.skipIf(typeof Element === 'undefined')('AcceleratedAnimation', () => {
 		expect(element.style.opacity).toBe('0');
 		expect(nativeAnimation.cancel).toHaveBeenCalledOnce();
 	});
+
+	/**
+	 * Regression test for motion 11.18.2:
+	 * "Animations with `transformTemplate` not hardware accelerated."
+	 */
+	describe('supports', () => {
+		function createOptions(props: Record<string, unknown>) {
+			const element = document.createElement('div');
+			Element.prototype.animate = vi.fn(() => ({}) as Animation);
+
+			return {
+				name: 'opacity',
+				motionValue: motionValue(1, {
+					owner: {
+						current: element,
+						getProps: () => props,
+					},
+				}),
+				keyframes: [1, 0],
+				duration: 100,
+			} as any;
+		}
+
+		test('supports a plain element', () => {
+			expect(AcceleratedAnimation.supports(createOptions({}))).toBe(true);
+		});
+
+		test('does not support elements with a transformTemplate', () => {
+			expect(AcceleratedAnimation.supports(createOptions({ transformTemplate: () => 'none' }))).toBe(false);
+		});
+	});
 });

--- a/packages/motion-start/src/animation/animators/waapi/utils/__tests__/linear.spec.ts
+++ b/packages/motion-start/src/animation/animators/waapi/utils/__tests__/linear.spec.ts
@@ -13,4 +13,14 @@ describe('generateLinearEasing', () => {
 		);
 		expect(generateLinearEasing(() => 0.5, 0)).toEqual('linear(0.5, 0.5)');
 	});
+
+	/**
+	 * Regression test for motion 12.17.0:
+	 * "Improved rounding for `linear()` easing curves."
+	 */
+	test('Rounds generated points to 4 decimal places', () => {
+		expect(generateLinearEasing((p) => p / 3, 30)).toEqual('linear(0, 0.1667, 0.3333)');
+		expect(generateLinearEasing(() => 1 / 3, 20)).toEqual('linear(0.3333, 0.3333)');
+		expect(generateLinearEasing(() => 0.000001, 20)).toEqual('linear(0, 0)');
+	});
 });

--- a/packages/motion-start/src/animation/animators/waapi/utils/linear.svelte.ts
+++ b/packages/motion-start/src/animation/animators/waapi/utils/linear.svelte.ts
@@ -17,7 +17,7 @@ export const generateLinearEasing = (
 	const numPoints = Math.max(Math.round(duration / resolution), 2);
 
 	for (let i = 0; i < numPoints; i++) {
-		points += easing(progress(0, numPoints - 1, i)) + ', ';
+		points += Math.round(easing(progress(0, numPoints - 1, i)) * 10000) / 10000 + ', ';
 	}
 
 	return `linear(${points.substring(0, points.length - 2)})`;

--- a/packages/motion-start/src/animation/generators/__tests__/spring.spec.ts
+++ b/packages/motion-start/src/animation/generators/__tests__/spring.spec.ts
@@ -130,16 +130,52 @@ describe('spring', () => {
 		expect(withoutDuration.length).toBeGreaterThan(4);
 	});
 
-	test('Spring defined as bounce and duration is resolved with correct velocity', () => {
+	test('Time-defined spring ignores velocity', () => {
 		const settings = {
 			keyframes: [500, 10],
 			bounce: 0.2,
 			duration: 1000,
 		};
-		const resolvedSpring = spring({ ...settings, velocity: 1000 });
+		const withVelocity = spring({ ...settings, velocity: 1000 });
+		const withoutVelocity = spring(settings);
 
-		expect(resolvedSpring.next(0).value).toBe(500);
-		expect(Math.floor(resolvedSpring.next(100).value)).toBe(420);
+		// Time-defined springs ignore velocity to prevent wild oscillation
+		// from interrupted animations
+		expect(withVelocity.next(0).value).toBe(withoutVelocity.next(0).value);
+		expect(withVelocity.next(100).value).toBe(withoutVelocity.next(100).value);
+	});
+
+	test('Time-defined spring with velocity does not wildly oscillate', () => {
+		/**
+		 * Time-defined springs (duration/bounce) must ignore inherited
+		 * velocity. When an animation is interrupted, the motionValue
+		 * carries velocity from the in-progress animation. If this leaks
+		 * into findSpring(), it changes the computed spring parameters
+		 * and causes massive oscillation on small-range animations.
+		 */
+		const settings = {
+			keyframes: [0, 100],
+			bounce: 0.2,
+			duration: 400,
+		};
+
+		const noVelocity = spring(settings);
+		const withVelocity = spring({ ...settings, velocity: 5000 });
+
+		let maxNoVelocity = 0;
+		let maxWithVelocity = 0;
+
+		for (let t = 0; t <= 400; t += 5) {
+			const noVel = noVelocity.next(t).value;
+			const withVel = withVelocity.next(t).value;
+
+			if (noVel > maxNoVelocity) maxNoVelocity = noVel;
+			if (withVel > maxWithVelocity) maxWithVelocity = withVel;
+		}
+
+		// Both should have identical mild overshoot (velocity is ignored)
+		expect(maxNoVelocity - 100).toBeLessThan(5);
+		expect(maxWithVelocity - 100).toBeLessThan(5);
 	});
 
 	test('Spring animating back to same number returns correct duration', () => {

--- a/packages/motion-start/src/animation/generators/spring/index.ts
+++ b/packages/motion-start/src/animation/generators/spring/index.ts
@@ -27,7 +27,13 @@ function getSpringOptions(options: SpringOptions) {
 	};
 	// stiffness/damping/mass overrides duration/bounce
 	if (!isSpringType(options, physicsKeys) && isSpringType(options, durationKeys)) {
-		const derived = findSpring(options);
+		// Time-defined springs should ignore inherited velocity.
+		// Velocity from interrupted animations can cause findSpring()
+		// to compute wildly different spring parameters, leading to
+		// massive oscillation on small-range animations.
+		springOptions.velocity = 0;
+
+		const derived = findSpring({ ...options, velocity: 0 });
 
 		springOptions = {
 			...springOptions,

--- a/packages/motion-start/src/animation/interfaces/__tests__/visual-element-target.spec.ts
+++ b/packages/motion-start/src/animation/interfaces/__tests__/visual-element-target.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Regression test for motion 11.16.6:
+ * "More movement values like `height` and `top` are now blocked by reduced motion."
+ */
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { VisualElement } from '../../../render/VisualElement.svelte.js';
+import { animateTarget } from '../visual-element-target.js';
+
+const animateMotionValue = vi.hoisted(() => vi.fn(() => vi.fn()));
+
+vi.mock('../motion-value.js', () => ({ animateMotionValue }));
+
+function createVisualElement(shouldReduceMotion: boolean) {
+	const values = new Map<string, { start: ReturnType<typeof vi.fn>; animation: undefined }>();
+
+	return {
+		shouldReduceMotion,
+		latestValues: {},
+		animationState: undefined,
+		getDefaultTransition: () => undefined,
+		getValue: (key: string) => {
+			if (key === 'willChange') return undefined;
+
+			if (!values.has(key)) {
+				values.set(key, { start: vi.fn(), animation: undefined });
+			}
+
+			return values.get(key);
+		},
+	} as unknown as VisualElement<unknown>;
+}
+
+function transitionFor(key: string) {
+	const call = animateMotionValue.mock.calls.find((args: unknown[]) => args[0] === key);
+	expect(call, `expected an animation to be created for "${key}"`).toBeDefined();
+	return (call as unknown as unknown[])[3];
+}
+
+describe('animateTarget with reduced motion', () => {
+	beforeEach(() => {
+		animateMotionValue.mockClear();
+	});
+
+	test('blocks transforms', () => {
+		animateTarget(createVisualElement(true), { x: 100 });
+
+		expect(transitionFor('x')).toEqual({ type: false });
+	});
+
+	test('blocks positional values like height, width, top and left', () => {
+		animateTarget(createVisualElement(true), { height: 100, width: 100, top: 100, left: 100 });
+
+		for (const key of ['height', 'width', 'top', 'left']) {
+			expect(transitionFor(key)).toEqual({ type: false });
+		}
+	});
+
+	test('does not block non-positional values like opacity', () => {
+		animateTarget(createVisualElement(true), { opacity: 0 });
+
+		expect(transitionFor('opacity')).not.toEqual({ type: false });
+	});
+
+	test('does not block anything when reduced motion is off', () => {
+		animateTarget(createVisualElement(false), { height: 100, x: 100 });
+
+		expect(transitionFor('height')).not.toEqual({ type: false });
+		expect(transitionFor('x')).not.toEqual({ type: false });
+	});
+});

--- a/packages/motion-start/src/animation/interfaces/visual-element-target.ts
+++ b/packages/motion-start/src/animation/interfaces/visual-element-target.ts
@@ -3,7 +3,7 @@ based on framer-motion@11.11.11,
 Copyright (c) 2018 Framer B.V.
 */
 
-import { transformProps } from '../../render/html/utils/transform.js';
+import { positionalKeys } from '../../render/dom/utils/unit-conversion.js';
 import type { AnimationTypeState } from '../../render/utils/animation-state.js';
 import type { VisualElement } from '../../render/VisualElement.svelte.js';
 import type { TargetAndTransition } from '../../types.js';
@@ -80,7 +80,7 @@ export function animateTarget(
 				key,
 				value,
 				valueTarget,
-				visualElement.shouldReduceMotion && transformProps.has(key) ? { type: false } : valueTransition,
+				visualElement.shouldReduceMotion && positionalKeys.has(key) ? { type: false } : valueTransition,
 				visualElement,
 				isHandoff
 			)

--- a/packages/motion-start/src/easing/__tests__/anticipate.spec.ts
+++ b/packages/motion-start/src/easing/__tests__/anticipate.spec.ts
@@ -1,0 +1,24 @@
+/**
+ * Regression test for motion 12.36.0:
+ * "Ensure `anticipate` easing returns `1` at `p === 1`."
+ */
+
+import { describe, expect, test } from 'vitest';
+import { anticipate } from '../anticipate.js';
+
+describe('anticipate easing', () => {
+	test('returns 0 at progress 0', () => {
+		expect(anticipate(0)).toBe(0);
+	});
+
+	test('is clamped to 1 at progress >= 1', () => {
+		expect(anticipate(1)).toBe(1);
+		expect(anticipate(1.5)).toBe(1);
+		expect(anticipate(2)).toBe(1);
+	});
+
+	test('anticipates backwards before moving forwards', () => {
+		expect(anticipate(0.1)).toBeLessThan(0);
+		expect(anticipate(0.9)).toBeGreaterThan(0.9);
+	});
+});

--- a/packages/motion-start/src/easing/anticipate.ts
+++ b/packages/motion-start/src/easing/anticipate.ts
@@ -5,4 +5,5 @@ Copyright (c) 2018 Framer B.V.
 
 import { backIn } from './back.js';
 
-export const anticipate = (p: number) => ((p *= 2) < 1 ? 0.5 * backIn(p) : 0.5 * (2 - Math.pow(2, -10 * (p - 1))));
+export const anticipate = (p: number) =>
+	p >= 1 ? 1 : (p *= 2) < 1 ? 0.5 * backIn(p) : 0.5 * (2 - Math.pow(2, -10 * (p - 1)));

--- a/packages/motion-start/src/render/dom/utils/__tests__/unit-conversion.spec.ts
+++ b/packages/motion-start/src/render/dom/utils/__tests__/unit-conversion.spec.ts
@@ -11,4 +11,32 @@ describe('positionalValues', () => {
 		expect(positionalValues.height(bbox, { paddingTop: '50px' })).toBe(250);
 		expect(positionalValues.height(bbox, { paddingBottom: '25px' })).toBe(275);
 	});
+
+	test('Ignores padding when box-sizing is border-box', () => {
+		const bbox = { x: { min: 0, max: 100 }, y: { min: 0, max: 300 } };
+
+		expect(positionalValues.width(bbox, { paddingLeft: '50px', boxSizing: 'border-box' })).toBe(100);
+		expect(
+			positionalValues.width(bbox, {
+				paddingLeft: '50px',
+				paddingRight: '25px',
+				boxSizing: 'border-box',
+			})
+		).toBe(100);
+		expect(positionalValues.height(bbox, { paddingTop: '50px', boxSizing: 'border-box' })).toBe(300);
+		expect(
+			positionalValues.height(bbox, {
+				paddingTop: '50px',
+				paddingBottom: '25px',
+				boxSizing: 'border-box',
+			})
+		).toBe(300);
+	});
+
+	test('Still subtracts padding when box-sizing is content-box', () => {
+		const bbox = { x: { min: 0, max: 100 }, y: { min: 0, max: 300 } };
+
+		expect(positionalValues.width(bbox, { paddingLeft: '50px', boxSizing: 'content-box' })).toBe(50);
+		expect(positionalValues.height(bbox, { paddingTop: '50px', boxSizing: 'content-box' })).toBe(250);
+	});
 });

--- a/packages/motion-start/src/render/dom/utils/unit-conversion.ts
+++ b/packages/motion-start/src/render/dom/utils/unit-conversion.ts
@@ -69,10 +69,18 @@ export function removeNonTranslationalTransform<I>(visualElement: VisualElement<
 
 export const positionalValues: { [key: string]: GetActualMeasurementInPixels } = {
 	// Dimensions
-	width: ({ x }, { paddingLeft = '0', paddingRight = '0' }) =>
-		x.max - x.min - Number.parseFloat(paddingLeft) - Number.parseFloat(paddingRight),
-	height: ({ y }, { paddingTop = '0', paddingBottom = '0' }) =>
-		y.max - y.min - Number.parseFloat(paddingTop) - Number.parseFloat(paddingBottom),
+	width: ({ x }, { paddingLeft = '0', paddingRight = '0', boxSizing }) => {
+		const width = x.max - x.min;
+		return boxSizing === 'border-box'
+			? width
+			: width - Number.parseFloat(paddingLeft) - Number.parseFloat(paddingRight);
+	},
+	height: ({ y }, { paddingTop = '0', paddingBottom = '0', boxSizing }) => {
+		const height = y.max - y.min;
+		return boxSizing === 'border-box'
+			? height
+			: height - Number.parseFloat(paddingTop) - Number.parseFloat(paddingBottom);
+	},
 
 	top: (_bbox, { top }) => Number.parseFloat(top as string),
 	left: (_bbox, { left }) => Number.parseFloat(left as string),

--- a/packages/motion-start/src/value/index.ts
+++ b/packages/motion-start/src/value/index.ts
@@ -47,7 +47,10 @@ interface ResolvedValues {
 
 export interface Owner {
 	current: HTMLElement | unknown;
-	getProps: () => { onUpdate?: (latest: ResolvedValues) => void };
+	getProps: () => {
+		onUpdate?: (latest: ResolvedValues) => void;
+		transformTemplate?(transform: ResolvedValues, generatedTransform: string): string;
+	};
 }
 
 export interface MotionValueOptions {

--- a/packages/motion-start/src/value/types/__tests__/index.spec.ts
+++ b/packages/motion-start/src/value/types/__tests__/index.spec.ts
@@ -110,6 +110,20 @@ describe('complex value type', () => {
 			'0% 0px var(--grey, 100) rgba(255, 255, 255, 1)'
 		);
 	});
+
+	/**
+	 * Regression test for motion 12.35.2:
+	 * "Detect divide-by-zero in CSS `calc()` values before making animatable templates."
+	 */
+	it('does not zero out divisors in calc() expressions', () => {
+		// calc() with division: divisor must not become 0 (division by zero => NaN)
+		expect(complex.getAnimatableNone('calc(var(--spacing) / 5)')).toBe('calc(var(--spacing) / 5)');
+
+		expect(complex.getAnimatableNone('calc(20% + 200px / 2)')).toBe('calc(0% + 0px / 2)');
+
+		// Multiplication should still zero out normally
+		expect(complex.getAnimatableNone('calc(20% + 200px * 2)')).toBe('calc(0% + 0px * 0)');
+	});
 });
 
 const red = {

--- a/packages/motion-start/src/value/types/complex/index.ts
+++ b/packages/motion-start/src/value/types/complex/index.ts
@@ -105,10 +105,31 @@ function createTransformer(source: string | number) {
 
 const convertNumbersToZero = (v: number | string | Color) => (typeof v === 'number' ? 0 : v);
 
+/**
+ * Convert a parsed value to its zero equivalent, but preserve numbers
+ * that act as divisors in CSS calc() expressions.
+ *
+ * analyseComplexValue extracts numbers from CSS strings and puts the
+ * surrounding text into a `split` template array. For example:
+ *   "calc(var(--gap) / 5)"  ->  values: [var(--gap), 5]
+ *                               split:  ["calc(", " / ", ")"]
+ *
+ * When building a zero-equivalent for animation, naively zeroing all
+ * numbers turns the divisor into 0 -> "calc(var(--gap) / 0)" -> NaN.
+ * We detect this by checking whether the text preceding a number
+ * (split[i]) ends with "/" - the CSS calc division operator.
+ */
+const convertToZero = (value: ComplexValues[number], splitBefore: string): ComplexValues[number] => {
+	if (typeof value === 'number') {
+		return splitBefore?.trim().endsWith('/') ? value : 0;
+	}
+	return convertNumbersToZero(value);
+};
+
 function getAnimatableNone(v: string | number) {
-	const parsed = parseComplexValue(v);
+	const { values, split } = analyseComplexValue(v);
 	const transformer = createTransformer(v);
-	return transformer(parsed.map(convertNumbersToZero));
+	return transformer(values.map((value, i) => convertToZero(value, split[i])));
 }
 
 export const complex = {


### PR DESCRIPTION
Ports seven behavioural bug fixes that upstream Motion has released since framer-motion 11.11.11, the version this library is a port of. Every fix was confirmed to still be present here before being changed, and each one ships a regression test that fails against the old source.

No architectural refactors were adopted — these are behaviour-only backports. The `getFinalKeyframe` speed fix (upstream 12.9.1) is deliberately **not** included; it's owned by the in-flight speed PR. The change to `AcceleratedAnimation.ts` is confined to a single condition inside `supports()` so it merges cleanly with that PR.

## Fixes

### 1. Reduced motion only blocked transforms, not positional values — upstream [11.16.6](https://github.com/motiondivision/motion/blob/main/CHANGELOG.md) ("More movement values like `height` and `top` are now blocked by reduced motion")

`animation/interfaces/visual-element-target.ts` gated the reduced-motion bypass on `transformProps.has(key)`, so a user with `prefers-reduced-motion: reduce` still got fully animated `height`, `width`, `top`, `left`, `right` and `bottom`. That's the accessibility defect this PR leads with. The gate now uses `positionalKeys`, which is the same set upstream moved to.

```diff
-visualElement.shouldReduceMotion && transformProps.has(key) ? { type: false } : valueTransition,
+visualElement.shouldReduceMotion && positionalKeys.has(key) ? { type: false } : valueTransition,
```

### 2. `width`/`height` unit conversion ignored `box-sizing: border-box` — upstream 12.36.0 ("Fixed `height` and `width: auto` animations with `box-sizing: border-box`")

`render/dom/utils/unit-conversion.ts` unconditionally subtracted padding from the measured bounding box. On a border-box element the bounding box *already* includes padding, so `width`/`height: auto` animations were measured short by the padding on both axes and visibly jumped. `positionalValues.width`/`height` now return the raw box when `boxSizing === 'border-box'`.

### 3. `calc()` divisors were zeroed, producing `NaN` — upstream 12.35.2 ("Detect divide-by-zero in CSS `calc()` values before making animatable templates")

`complex.getAnimatableNone()` mapped every parsed number to `0`, so `calc(var(--spacing) / 5)` became `calc(var(--spacing) / 0)` and the resulting animatable "none" template evaluated to `NaN`. Numbers whose preceding template segment ends in `/` are now preserved; multiplication and everything else still zero out as before.

### 4. `anticipate` easing overshot past `1` — upstream 12.36.0 ("Ensure `anticipate` easing returns `1` at `p === 1`")

`easing/anticipate.ts` is now clamped: `p >= 1 ? 1 : …`.

### 5. WAAPI `linear()` easing emitted unrounded floats — upstream 12.17.0 ("Improved rounding for `linear()` easing curves")

`generateLinearEasing` concatenated raw float output, producing points like `0.16666666666666666`. Points are now rounded to four decimal places, matching upstream, which shortens the generated easing string without perceptible precision loss.

### 6. `transformTemplate` was not checked in the accelerated-animation support test — upstream 11.18.2 ("Animations with `transformTemplate` not hardware accelerated")

`AcceleratedAnimation.supports()` never asked whether the element had a `transformTemplate`. WAAPI animations bypass the render pipeline, so such an element lost its custom transform ordering for the whole animation. One extra condition, plus the `Owner['getProps']` type widened to declare `transformTemplate`.

### 7. Spring velocity leaked into duration-defined springs — upstream 12.34.3 ("Ensure `velocity` is never transferred to a time-derived spring")

`getSpringOptions` passed the inherited velocity straight into `findSpring()` when a spring was defined by `duration`/`bounce`. Velocity carried over from an interrupted animation therefore changed the *derived spring parameters*, causing massive oscillation on small-range animations. Time-defined springs now resolve with `velocity: 0`.

The port's old test `Spring defined as bounce and duration is resolved with correct velocity` encoded exactly the buggy behaviour, so it has been replaced with upstream's two current tests (`Time-defined spring ignores velocity` and `Time-defined spring with velocity does not wildly oscillate`).

## Nothing was skipped

All seven items were confirmed to still carry the old behaviour here. Verified by stashing only the source changes and re-running the new tests — 8 failures across all 7 areas, all green with the fixes applied.

## Testing

- `npx vitest --run` (full suite, includes typecheck): **641 passed, 1 skipped, no type errors**
- Biome reports no new diagnostics for the changed files; the two new test files are clean. (The repo has substantial pre-existing Biome findings that this PR does not touch.)

A changeset is included.