### PR TITLE
Fix spring sub-frame sampling, MotionValue reactive-read refcount, and PresenceChild map

### DIFF
--- a/.changeset/tidy-spiders-jam.md
+++ b/.changeset/tidy-spiders-jam.md
@@ -1,0 +1,19 @@
+---
+"motion-start": patch
+---
+
+Fix three independent correctness bugs ported from framer-motion v11.11.11.
+
+- `useSpring` dropped upstream's sub-frame sampling. When a spring was retargeted before its
+  previous animation had rendered a frame, the replacement animation started from the stale
+  position instead of the interpolated one. The previous animation is now sampled with
+  `frameData.delta` before being replaced, matching upstream.
+- Reading `MotionValue.current` reactively registered a real `change` listener, and the number
+  of `change` listeners is what decides whether an animation is auto-stopped once the last
+  consumer goes away. Destroying the last component that reactively read a standalone
+  `MotionValue` therefore cancelled an in-flight animation. Svelte's signal subscriber is now
+  tracked separately from user `on('change')` subscribers, so it no longer participates in that
+  refcount. Reactive behaviour of `.current` is unchanged.
+- `PresenceChild` wrapped its registered-children `Map` in `$state`, which is a no-op - Svelte 5
+  only proxies plain objects and arrays. The wrapper has been dropped since the map's contents
+  are only read imperatively and were never meant to drive reactivity.

--- a/packages/motion-start/src/components/AnimatePresence/PresenceChild/PresenceChild.svelte
+++ b/packages/motion-start/src/components/AnimatePresence/PresenceChild/PresenceChild.svelte
@@ -29,7 +29,11 @@ function newChildrenMap(): Map<string | number, boolean> {
 		children: desendants,
 	}: Props = $props();
 
-	const presenceChildren = $state(newChildrenMap());
+	// A plain Map: its contents are only ever read imperatively (from
+	// `handleExitComplete` and inside effects that track `isPresent`), so it
+	// does not need to drive reactivity. `$state(new Map())` would have been a
+	// no-op here anyway - Svelte only proxies plain objects and arrays.
+	const presenceChildren = newChildrenMap();
 	const id = $props.id();
 
 	// Keep one mutable context object alive so child registration and popLayout

--- a/packages/motion-start/src/value/__tests__/UseSpringFixture.svelte
+++ b/packages/motion-start/src/value/__tests__/UseSpringFixture.svelte
@@ -1,0 +1,14 @@
+<svelte:options runes />
+
+<script lang="ts">
+import type { SpringOptions } from '../../animation/types.js';
+import { useSpring } from '../use-spring.js';
+
+interface Props {
+	config?: SpringOptions;
+}
+
+let { config = {} }: Props = $props();
+
+export const spring = useSpring(0, () => config);
+</script>

--- a/packages/motion-start/src/value/__tests__/motion-value-reactivity.svelte.spec.ts
+++ b/packages/motion-start/src/value/__tests__/motion-value-reactivity.svelte.spec.ts
@@ -1,5 +1,7 @@
 import { flushSync, mount, unmount } from 'svelte';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { animate } from '../../animation/animate/index.js';
+import { frame } from '../../frameloop/index.js';
 import { collectMotionValues, type MotionValue, motionValue } from '../index.js';
 import MotionValueReactiveReadsFixture from './MotionValueReactiveReadsFixture.svelte';
 
@@ -44,5 +46,31 @@ describe('MotionValue reactive reads', () => {
 		value.get();
 
 		expect(collected).toEqual([value]);
+	});
+
+	it('does not stop an animation when a component that reactively read current unmounts', async () => {
+		const value = motionValue(0);
+
+		animate(value, 100, { duration: 10 });
+		expect(value.isAnimating()).toBe(true);
+
+		const component = mount(MotionValueReactiveReadsFixture, {
+			target: document.body,
+			props: { value, oncurrent: vi.fn(), onget: vi.fn() },
+		});
+		flushSync();
+
+		await unmount(component);
+		flushSync();
+
+		// Auto-stopping runs on the next read step, so give the frameloop a chance
+		// to process the teardown before asserting.
+		await new Promise<void>((resolve) => {
+			frame.postRender(() => resolve());
+		});
+
+		expect(value.isAnimating()).toBe(true);
+
+		value.stop();
 	});
 });

--- a/packages/motion-start/src/value/__tests__/motion-value-reactivity.svelte.spec.ts
+++ b/packages/motion-start/src/value/__tests__/motion-value-reactivity.svelte.spec.ts
@@ -5,6 +5,22 @@ import { frame } from '../../frameloop/index.js';
 import { collectMotionValues, type MotionValue, motionValue } from '../index.js';
 import MotionValueReactiveReadsFixture from './MotionValueReactiveReadsFixture.svelte';
 
+const subscriptionManagers = vi.hoisted(() => ({ constructed: 0 }));
+
+vi.mock('../../utils/subscription-manager.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../../utils/subscription-manager.js')>();
+
+	return {
+		...actual,
+		SubscriptionManager: new Proxy(actual.SubscriptionManager, {
+			construct(target, args) {
+				subscriptionManagers.constructed++;
+				return Reflect.construct(target, args);
+			},
+		}),
+	};
+});
+
 let instance: ReturnType<typeof mount> | undefined;
 
 afterEach(async () => {
@@ -72,5 +88,24 @@ describe('MotionValue reactive reads', () => {
 		expect(value.isAnimating()).toBe(true);
 
 		value.stop();
+	});
+
+	it('allocates the reactive subscription manager only once current is read reactively', () => {
+		subscriptionManagers.constructed = 0;
+
+		const value = motionValue(0);
+		value.set(1);
+
+		// A MotionValue that is never read inside a $derived/$effect and has no
+		// event listeners should not allocate a SubscriptionManager at all.
+		expect(subscriptionManagers.constructed).toBe(0);
+
+		instance = mount(MotionValueReactiveReadsFixture, {
+			target: document.body,
+			props: { value, oncurrent: vi.fn(), onget: vi.fn() },
+		});
+		flushSync();
+
+		expect(subscriptionManagers.constructed).toBe(1);
 	});
 });

--- a/packages/motion-start/src/value/__tests__/use-spring.svelte.spec.ts
+++ b/packages/motion-start/src/value/__tests__/use-spring.svelte.spec.ts
@@ -1,0 +1,84 @@
+import { flushSync, mount, unmount } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Driver } from '../../animation/animators/drivers/types.js';
+import type { SpringOptions } from '../../animation/types.js';
+import { frame, frameData } from '../../frameloop/index.js';
+import { time } from '../../frameloop/sync-time.js';
+import UseSpringFixture from './UseSpringFixture.svelte';
+
+const startedKeyframes: number[][] = [];
+
+vi.mock('../../animation/animators/MainThreadAnimation.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../../animation/animators/MainThreadAnimation.js')>();
+
+	return {
+		...actual,
+		animateValue: (options: Parameters<typeof actual.animateValue>[0]) => {
+			startedKeyframes.push([...options.keyframes]);
+			return actual.animateValue(options);
+		},
+	};
+});
+
+/**
+ * A driver that never ticks, so the animation it drives stays at `time === 0`.
+ * This reproduces the case the sampling behaviour exists for: a spring that is
+ * retargeted before its previous animation rendered a frame.
+ */
+const idleDriver: Driver = () => {
+	const doNothing = () => undefined;
+
+	return {
+		start: doNothing,
+		stop: doNothing,
+		now: () => (frameData.isProcessing ? frameData.timestamp : time.now()),
+	};
+};
+
+const nextFrame = () => new Promise<void>((resolve) => frame.postRender(() => resolve()));
+
+let instance: ReturnType<typeof mount> | undefined;
+
+beforeEach(() => {
+	startedKeyframes.length = 0;
+});
+
+afterEach(async () => {
+	if (instance) await unmount(instance);
+	instance = undefined;
+	document.body.innerHTML = '';
+});
+
+describe('useSpring', () => {
+	it('samples the in-flight spring when retargeted before it has rendered a frame', async () => {
+		const component = mount(UseSpringFixture, {
+			target: document.body,
+			props: {
+				config: { stiffness: 200, damping: 10, driver: idleDriver } as SpringOptions,
+			},
+		});
+		instance = component;
+		flushSync();
+
+		const { spring } = component;
+
+		spring.set(100);
+		await nextFrame();
+
+		expect(startedKeyframes).toEqual([[0, 100]]);
+		expect(spring.get()).toBe(0);
+
+		// The first animation has not rendered a frame yet, so retargeting must
+		// sample it forward and start the replacement from that position.
+		spring.set(50);
+		await nextFrame();
+
+		expect(startedKeyframes).toHaveLength(2);
+
+		const [, retargetKeyframes] = startedKeyframes;
+
+		expect(retargetKeyframes[1]).toBe(50);
+		expect(retargetKeyframes[0]).toBeGreaterThan(0);
+		expect(retargetKeyframes[0]).toBe(spring.get());
+	});
+});

--- a/packages/motion-start/src/value/index.ts
+++ b/packages/motion-start/src/value/index.ts
@@ -84,11 +84,26 @@ export class MotionValue<V = any> {
 	private _current: V | undefined;
 
 	/**
+	 * Subscribers registered by Svelte's signal system when `current` is read
+	 * reactively.
+	 *
+	 * These are deliberately kept out of the `change` event's
+	 * `SubscriptionManager` because the size of that manager is used to decide
+	 * whether an animation should be auto-stopped once the last consumer goes
+	 * away. Reactive reads of `current` must not participate in that refcount,
+	 * otherwise unmounting a component that merely read the value would cancel
+	 * an in-flight animation.
+	 *
+	 * @internal
+	 */
+	readonly #reactiveSubscribers = new SubscriptionManager<() => void>();
+
+	/**
 	 * Svelte signal subscriber — registers this value as a reactive dependency
 	 * when `current` is read inside a `$derived` or `$effect`.
 	 */
 	readonly #subscribe = createSubscriber((update) => {
-		return this.on('change', update);
+		return this.#reactiveSubscribers.add(update);
 	});
 
 	/**
@@ -339,8 +354,12 @@ export class MotionValue<V = any> {
 		this.setCurrent(v);
 
 		// Update update subscribers
-		if (this._current !== this.prev && this.events.change) {
-			this.events.change.notify(this._current);
+		if (this._current !== this.prev) {
+			if (this.events.change) {
+				this.events.change.notify(this._current);
+			}
+
+			this.#reactiveSubscribers.notify();
 		}
 
 		// Update render subscribers

--- a/packages/motion-start/src/value/index.ts
+++ b/packages/motion-start/src/value/index.ts
@@ -94,15 +94,21 @@ export class MotionValue<V = any> {
 	 * otherwise unmounting a component that merely read the value would cancel
 	 * an in-flight animation.
 	 *
+	 * Allocated lazily on first reactive subscription, mirroring how `events`
+	 * managers are only created on first `on()`. Most `MotionValue`s are never
+	 * read inside a `$derived`/`$effect`, so this stays undefined for them.
+	 *
 	 * @internal
 	 */
-	readonly #reactiveSubscribers = new SubscriptionManager<() => void>();
+	#reactiveSubscribers?: SubscriptionManager<() => void>;
 
 	/**
 	 * Svelte signal subscriber — registers this value as a reactive dependency
 	 * when `current` is read inside a `$derived` or `$effect`.
 	 */
 	readonly #subscribe = createSubscriber((update) => {
+		this.#reactiveSubscribers ??= new SubscriptionManager<() => void>();
+
 		return this.#reactiveSubscribers.add(update);
 	});
 
@@ -160,8 +166,6 @@ export class MotionValue<V = any> {
 	 * @internal
 	 */
 	liveStyle?: boolean;
-
-	// #subscribe: ReturnType<typeof createSubscriber> | null = null;
 
 	/**
 	 * @param init - The initiating value
@@ -359,7 +363,7 @@ export class MotionValue<V = any> {
 				this.events.change.notify(this._current);
 			}
 
-			this.#reactiveSubscribers.notify();
+			this.#reactiveSubscribers?.notify();
 		}
 
 		// Update render subscribers

--- a/packages/motion-start/src/value/use-spring.ts
+++ b/packages/motion-start/src/value/use-spring.ts
@@ -6,7 +6,7 @@ Copyright (c) 2018 Framer B.V.
 import type { SpringOptions } from '../animation/types.js';
 import { type MainThreadAnimation, animateValue } from '../animation/animators/MainThreadAnimation.js';
 import { useMotionConfigContext } from '../context/MotionConfigContext.svelte.js';
-import { frame } from '../frameloop/index.js';
+import { frame, frameData } from '../frameloop/index.js';
 import type { MotionValue } from './index.js';
 import { useMotionValue } from './use-motion-value.svelte.js';
 import { isMotionValue } from './utils/is-motion-value.js';
@@ -51,6 +51,15 @@ export const useSpring = (source: MotionValue | number, config: MaybeGetter<Spri
 	let latestSetter = noop<number>;
 
 	const startAnimation = () => {
+		/**
+		 * If the previous animation hasn't had the chance to even render a frame, render it now.
+		 */
+		const animation = activeSpringAnimation;
+
+		if (animation && animation.time === 0) {
+			animation.sample(frameData.delta);
+		}
+
 		stopAnimation();
 
 		activeSpringAnimation = animateValue({


### PR DESCRIPTION
Three small, independent correctness fixes against framer-motion v11.11.11 behaviour.

> [!NOTE]
> **File overlap with #80.** PR #80 (`jonathonrp-backport-upstream-bug-fixes`) also edits `packages/motion-start/src/value/index.ts`, widening `Owner['getProps']` (line 50) to declare `transformTemplate`. That is written as a **method shorthand on purpose** — it relies on parameter bivariance for the `AcceleratedAnimation.supports()` transformTemplate guard, so it must not be "tidied" into a property signature.
>
> This PR's hunks in that file are confined to the `MotionValue` class body (the `#reactiveSubscribers`/`#subscribe` fields, a stale commented-out line, and the notify branch of `updateAndNotify`); `Owner`/`getProps` is untouched, nothing was reformatted or reorganised, and the change to how `change` subscribers are stored is additive with no bearing on the `Owner` typing. The two diffs do not overlap and should merge cleanly in either order. Likely order is #80 first, then this rebased on top.

## 1. `value/use-spring.ts` — restore dropped sub-frame sampling

Upstream calls `animation.sample(frameData.delta)` when retargeting a spring whose previous animation has not yet rendered a frame, so the replacement spring starts from the correct interpolated position. The port dropped that call, so a spring retargeted before its first render restarted from the stale position (a visible "snap back" on rapid retargets).

Restored the upstream branch, adapted to this file's structure (`activeSpringAnimation` is a plain closure variable rather than a React ref), and added `frameData` to the existing frameloop import.

**Test:** `src/value/__tests__/use-spring.svelte.spec.ts` mounts a spring, sets a target, and retargets it before the first animation has ticked. It drives the spring with an idle `driver` (never ticks) so the precondition `animation.time === 0` is deterministic rather than dependent on frameloop queue ordering, spies on `animateValue` to capture the keyframes each animation is started with, and asserts the retargeted animation starts from the sampled position rather than `0`. Verified failing before the fix (`expected 0 to be greater than 0`).

## 2. `value/index.ts` — reactive `.current` reads no longer cancel animations

`.current` was made reactive with `createSubscriber((update) => this.on('change', update))`, which registers a genuine `change` listener. `MotionValue.on('change', …)`'s unsubscribe schedules a `frame.read` that calls `this.stop()` when `events.change.getSize()` hits zero. So for a standalone `MotionValue` (not owned by a `VisualElement`), unmounting the last component that merely *read* `.current` reactively cancelled an in-flight animation. Upstream has no such coupling — there, subscriber count and animation lifetime are independent in this case.

Fix: Svelte's signal subscriber is now held in its own `SubscriptionManager` (`#reactiveSubscribers`), notified from `updateAndNotify` under the same `_current !== prev` condition as the `change` event, immediately after `events.change.notify(...)`. It is therefore invisible to the refcount that gates auto-stop. Reactive behaviour of `.current` is unchanged, and the existing "when all change listeners removed, stop animation" behaviour for real `on('change')` subscribers still holds.

### Lazy allocation

`#reactiveSubscribers` is declared as an optional field and constructed on first reactive subscription (inside the `createSubscriber` start callback), with `#reactiveSubscribers?.notify()` at the notify site.

This matters because `SubscriptionManager` is not free: constructing one allocates the instance, its backing `subscriptions: Handler[] = []` array, and two bound functions — `add` and `notify` are **instance fields**, not prototype methods — so roughly four allocations each time. MotionValues are created per animated property per element, so on a list of a few hundred animated items an eager class-field initializer would be a meaningful and permanent cost, and the overwhelming majority of MotionValues are never read inside a `$derived`/`$effect`, leaving the manager empty for its entire life. Lazy allocation keeps the port aligned with upstream's practice of lazily creating `events.change` on first `on()` rather than allocating event managers up front.

`createSubscriber` itself is still constructed eagerly per instance, unchanged from before this PR — for the record it only allocates a closure, a `source(0)` signal and the returned function, and registers no listeners or effects until the first tracked read.

Also removed a stale `// #subscribe: ReturnType<typeof createSubscriber> | null = null;` left over from an earlier approach, which was misleading next to the real `#subscribe` defined above it.

**Tests** in `src/value/__tests__/motion-value-reactivity.svelte.spec.ts`:
- animate a standalone `MotionValue`, mount and unmount a component that reads `.current`, assert the animation is still running after the frameloop has processed the teardown. Verified failing before the fix (`expected false to be true`).
- assert lazy allocation: `SubscriptionManager` construction is counted via a `vi.mock` `Proxy` `construct` trap (the field itself is a real `#private` and can't be read from a test, so this avoids weakening the source to make it observable). A `MotionValue` that is only `set()` constructs zero managers; mounting a component that reads `.current` constructs exactly one. Verified failing with an eager field initializer (`expected 1 to be +0`).

## 3. `components/AnimatePresence/PresenceChild/PresenceChild.svelte` — remove no-op `$state(new Map())`

**Chose: drop the `$state` wrapper** (not `SvelteMap`).

`presenceChildren` is only ever read imperatively: `handleExitComplete` and `register` are context callbacks invoked by descendants, and the two `$effect`s that touch it are driven by `isPresent` — the `forEach`/`size` reads happen inside an effect body already tracking `isPresent`, and the `size` read is inside a `tick().then()` callback where nothing is tracked anyway. Nothing renders from the map or derives from its contents, so it was never meant to drive reactivity, and `$state` around a native `Map` is a no-op in Svelte 5 regardless (only plain objects and arrays are proxied). Switching to `SvelteMap` would have added reactive overhead for no consumer. Added a comment recording the reasoning. The map is local to the component and never passed out, so nothing depended on the wrapper.

## Verification

- `vitest --run src/value`: 74 passed (11 files), including `motion-value-reactivity.svelte.spec.ts` and `use-spring.svelte.spec.ts`.
- `vitest --run` over `src/value`, `src/components/AnimatePresence` and `src/render`: 200 passed.
- Full suite: 621 passed. The failures seen under full-suite parallel load (`package-imports.spec.ts`, `Reorder production SSR`) are known pre-existing flakes that pass in isolation, including on a clean stashed tree.
- `bun run --filter motion-start check` (svelte-check): 0 errors, 0 warnings.
- Biome: no new lint findings on the changed files (repo-wide `biome check` is already failing on pre-existing formatting/line-ending issues; baseline compared file-by-file).
- Changeset added: `.changeset/tidy-spiders-jam.md` (`patch`).
