### PR TITLE
Fix finished-promise recreation on animation completion

### DIFF
--- a/.changeset/gentle-jars-shave.md
+++ b/.changeset/gentle-jars-shave.md
@@ -1,0 +1,5 @@
+---
+"motion-start": patch
+---
+
+Fix finished promises being recreated the instant an animation completes, which made anything awaiting or chaining a controls object after completion hang forever. The finished promise is now only recreated when a finished animation is replayed, animations expose a `finished` getter that is read fresh on every `then()`, and `GroupPlaybackControls` awaits its members' own `finished` promises (falling back to the member itself for controls that don't expose one) instead of consuming them as one-shot thenables. Empty groups still resolve immediately.

--- a/packages/motion-start/src/animation/GroupPlaybackControls.ts
+++ b/packages/motion-start/src/animation/GroupPlaybackControls.ts
@@ -16,8 +16,18 @@ export class GroupPlaybackControls implements AnimationPlaybackControls {
 		this.animations = animations.filter(Boolean) as AnimationPlaybackControls[];
 	}
 
+	/**
+	 * Read each member's own finished promise afresh rather than treating the
+	 * controls themselves as one-shot thenables. Members that predate the
+	 * `finished` getter fall back to the controls object, which is itself a
+	 * thenable. An empty group resolves immediately.
+	 */
+	get finished(): Promise<void> {
+		return Promise.all(this.animations.map((animation) => animation.finished ?? animation)).then(() => undefined);
+	}
+
 	then(onResolve: VoidFunction, onReject?: VoidFunction) {
-		return Promise.all(this.animations).then(onResolve).catch(onReject);
+		return this.finished.then(onResolve).catch(onReject);
 	}
 
 	private getTimeValue() {
@@ -81,7 +91,7 @@ export class GroupPlaybackControls implements AnimationPlaybackControls {
 		return max;
 	}
 
-	private runAll(methodName: keyof Omit<AnimationPlaybackControls, PropNames | 'then' | 'state'>) {
+	private runAll(methodName: keyof Omit<AnimationPlaybackControls, PropNames | 'then' | 'state' | 'finished'>) {
 		this.animations.forEach((controls) => controls[methodName]());
 	}
 

--- a/packages/motion-start/src/animation/__tests__/GroupPlaybackControls.spec.ts
+++ b/packages/motion-start/src/animation/__tests__/GroupPlaybackControls.spec.ts
@@ -6,6 +6,8 @@
 
 import { describe, test, expect, vi } from 'vitest';
 import { GroupPlaybackControls } from '../GroupPlaybackControls.js';
+import { animateValue } from '../animators/MainThreadAnimation.js';
+import { syncDriver, withTimeout } from '../animators/__tests__/utils.js';
 import type { AnimationPlaybackControls } from '../types.js';
 
 function createTestAnimationControls(
@@ -236,5 +238,77 @@ describe('GroupPlaybackControls', () => {
 		const controls = new GroupPlaybackControls([]);
 
 		expect(controls.duration).toEqual(0);
+	});
+
+	/**
+	 * Regression tests for https://github.com/motiondivision/motion/issues/3145
+	 * and https://github.com/motiondivision/motion/issues/3144
+	 *
+	 * The group used to hand the member controls straight to Promise.all, which
+	 * consumed each member's finished promise once. Awaiting the group after it
+	 * had completed would then wait on promises that never resolve.
+	 */
+	describe('finished promise', () => {
+		const createAnimation = () =>
+			animateValue({
+				keyframes: [0, 100],
+				duration: 100,
+				ease: 'linear',
+				driver: syncDriver(20),
+			});
+
+		test('await resolves once all animations complete', async () => {
+			const controls = new GroupPlaybackControls([createAnimation(), createAnimation()]);
+
+			await withTimeout(controls, 'await of a running group never resolved');
+		});
+
+		test('a second await after natural completion still resolves', async () => {
+			const controls = new GroupPlaybackControls([createAnimation(), createAnimation()]);
+
+			await withTimeout(controls, 'first await never resolved');
+			await withTimeout(controls, 'await after completion never resolved');
+			await withTimeout(controls.finished, '.finished after completion never resolved');
+		});
+
+		test('.then() fires after natural completion', async () => {
+			const controls = new GroupPlaybackControls([createAnimation(), createAnimation()]);
+
+			await withTimeout(controls, 'first await never resolved');
+
+			const onFinished = vi.fn();
+
+			await withTimeout(
+				new Promise<void>((resolve) => {
+					controls.then(() => {
+						onFinished();
+						resolve();
+					});
+				}),
+				'.then() after completion never fired'
+			);
+
+			expect(onFinished).toHaveBeenCalledTimes(1);
+		});
+
+		test('An empty group resolves immediately', async () => {
+			const controls = new GroupPlaybackControls([]);
+
+			await withTimeout(controls, 'await of an empty group never resolved');
+			await withTimeout(controls, 'second await of an empty group never resolved');
+			await withTimeout(controls.finished, '.finished of an empty group never resolved');
+		});
+
+		test('Falls back to members that do not expose finished', async () => {
+			const a = createTestAnimationControls();
+			const b = createTestAnimationControls();
+
+			expect(a.finished).toBeUndefined();
+
+			const controls = new GroupPlaybackControls([a, b]);
+
+			await withTimeout(controls, 'await of a legacy-member group never resolved');
+			await withTimeout(controls, 'second await of a legacy-member group never resolved');
+		});
 	});
 });

--- a/packages/motion-start/src/animation/animators/AcceleratedAnimation.ts
+++ b/packages/motion-start/src/animation/animators/AcceleratedAnimation.ts
@@ -354,8 +354,12 @@ export class AcceleratedAnimation<T extends string | number> extends BaseAnimati
 		this.isStopped = true;
 		if (this.state === 'idle') return;
 
+		/**
+		 * Resolve, but don't recreate, the finished promise. A stopped animation
+		 * can't be replayed (isStopped short-circuits play()) so anything awaiting
+		 * it after this point must still resolve.
+		 */
 		this.resolveFinishedPromise();
-		this.updateFinishedPromise();
 
 		const { resolved } = this;
 		if (!resolved) return;

--- a/packages/motion-start/src/animation/animators/BaseAnimation.ts
+++ b/packages/motion-start/src/animation/animators/BaseAnimation.ts
@@ -185,12 +185,21 @@ export abstract class BaseAnimation<T extends string | number, Resolved> impleme
 	onPostResolved() {}
 
 	/**
+	 * A promise that resolves when the animation finishes. It is only replaced
+	 * when the animation is replayed, so awaiting a finished animation always
+	 * resolves immediately.
+	 */
+	get finished(): Promise<void> {
+		return this.currentFinishedPromise;
+	}
+
+	/**
 	 * Allows the returned animation to be awaited or promise-chained. Currently
 	 * resolves when the animation finishes at all but in a future update could/should
 	 * reject if its cancels.
 	 */
 	then(resolve: VoidFunction, reject?: VoidFunction) {
-		return this.currentFinishedPromise.then(resolve, reject);
+		return this.finished.then(resolve, reject);
 	}
 
 	flatten() {

--- a/packages/motion-start/src/animation/animators/MainThreadAnimation.ts
+++ b/packages/motion-start/src/animation/animators/MainThreadAnimation.ts
@@ -511,14 +511,18 @@ export class MainThreadAnimation<T extends string | number> extends BaseAnimatio
 			this.tick(this.cancelTime);
 		}
 		this.teardown();
-		this.updateFinishedPromise();
 	}
 
+	/**
+	 * The finished promise is resolved here but deliberately *not* recreated.
+	 * Recreating it on finish means anything that awaits or chains the animation
+	 * after it has completed would wait on a promise that never resolves. It is
+	 * only recreated in play() when a finished animation is replayed.
+	 */
 	private teardown() {
 		this.state = 'idle';
 		this.stopDriver();
 		this.resolveFinishedPromise();
-		this.updateFinishedPromise();
 		this.startTime = this.cancelTime = null;
 		this.resolver.cancel();
 	}

--- a/packages/motion-start/src/animation/animators/__tests__/MainThreadAnimation.spec.ts
+++ b/packages/motion-start/src/animation/animators/__tests__/MainThreadAnimation.spec.ts
@@ -4,12 +4,12 @@
  * Ported from packages/framer-motion/src/animation/animators/__tests__/MainThreadAnimation.test.ts
  */
 
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, vi } from 'vitest';
 import { MainThreadAnimation, animateValue } from '../MainThreadAnimation.js';
 import { reverseEasing } from '../../../easing/modifiers/reverse.js';
 import { noop } from '../../../utils/noop.js';
 import type { ValueAnimationOptions } from '../../types.js';
-import { syncDriver, persistentSyncDriver } from './utils.js';
+import { syncDriver, persistentSyncDriver, withTimeout } from './utils.js';
 import { KeyframeResolver } from '../../../render/utils/KeyframesResolver.js';
 
 /**
@@ -1437,5 +1437,116 @@ describe('MainThreadAnimation', () => {
 		await nextFrame();
 
 		expect(output).toEqual([100, 80, 60, 40, 20, 0]);
+	});
+
+	/**
+	 * Regression tests for https://github.com/motiondivision/motion/issues/3145
+	 * and https://github.com/motiondivision/motion/issues/3144
+	 *
+	 * teardown() used to immediately replace the just-resolved finished promise
+	 * with a fresh, unresolved one. Anything awaiting or chaining the animation
+	 * after it had completed would then wait forever.
+	 */
+	describe('finished promise', () => {
+		test('await resolves once the animation completes', async () => {
+			const animation = animateValue({
+				keyframes: [0, 100],
+				duration: 100,
+				ease: 'linear',
+				driver: syncDriver(20),
+			});
+
+			await withTimeout(animation, 'await of a running animation never resolved');
+
+			expect(animation.state).toBe('finished');
+		});
+
+		test('a second await after natural completion still resolves', async () => {
+			const animation = animateValue({
+				keyframes: [0, 100],
+				duration: 100,
+				ease: 'linear',
+				driver: syncDriver(20),
+			});
+
+			await withTimeout(animation, 'first await never resolved');
+			await withTimeout(animation, 'await after completion never resolved');
+			await withTimeout(animation.finished, '.finished after completion never resolved');
+		});
+
+		test('.then() fires after natural completion', async () => {
+			const animation = animateValue({
+				keyframes: [0, 100],
+				duration: 100,
+				ease: 'linear',
+				driver: syncDriver(20),
+			});
+
+			await withTimeout(animation, 'first await never resolved');
+
+			const onFinished = vi.fn();
+
+			await withTimeout(
+				new Promise<void>((resolve) => {
+					animation.then(() => {
+						onFinished();
+						resolve();
+					});
+				}),
+				'.then() after completion never fired'
+			);
+
+			expect(onFinished).toHaveBeenCalledTimes(1);
+		});
+
+		test('replaying a finished animation creates a new finished promise', async () => {
+			const animation = animateValue({
+				keyframes: [0, 100],
+				duration: 100,
+				ease: 'linear',
+				driver: persistentSyncDriver(20),
+			});
+
+			await withTimeout(animation, 'first await never resolved');
+
+			const firstFinished = animation.finished;
+
+			animation.play();
+
+			expect(animation.finished).not.toBe(firstFinished);
+
+			await withTimeout(animation, 'await of a replayed animation never resolved');
+			await withTimeout(animation, 'await after replay completion never resolved');
+		});
+
+		test('a cancelled animation resolves subsequent awaits', async () => {
+			const animation = animateValue({
+				keyframes: [0, 100],
+				duration: 100,
+				ease: linear,
+				driver: syncDriver(20),
+				onUpdate: (v) => {
+					if (v === 40) animation.cancel();
+				},
+			});
+
+			await withTimeout(animation, 'await of a cancelled animation never resolved');
+			await withTimeout(animation, 'await after cancellation never resolved');
+		});
+
+		test('a stopped animation resolves subsequent awaits', async () => {
+			const animation = animateValue({
+				keyframes: [0, 100],
+				duration: 100,
+				ease: linear,
+				driver: syncDriver(20),
+				onUpdate: (v) => {
+					if (v === 40) animation.stop();
+				},
+			});
+
+			await withTimeout(animation, 'await of a stopped animation never resolved');
+			await withTimeout(animation, 'await after stop never resolved');
+		});
 	});
 });

--- a/packages/motion-start/src/animation/animators/__tests__/utils.ts
+++ b/packages/motion-start/src/animation/animators/__tests__/utils.ts
@@ -111,3 +111,32 @@ export function animateSync(animation: KeyframeGenerator<string | number>, timeS
 
 	return output;
 }
+
+/**
+ * A minimal thenable, loose enough to accept both real promises and the
+ * animation playback controls, whose `then` doesn't receive a value.
+ */
+export interface AwaitableLike {
+	then: (onResolve: VoidFunction, onReject?: VoidFunction) => unknown;
+}
+
+/**
+ * Rejects if the provided thenable hasn't settled within `timeout` ms, so a
+ * promise that never resolves fails the test fast instead of stalling the suite.
+ */
+export function withTimeout(thenable: AwaitableLike, message = 'Timed out', timeout = 1000): Promise<void> {
+	return new Promise<void>((resolve, reject) => {
+		const timeoutId = setTimeout(() => reject(new Error(message)), timeout);
+
+		thenable.then(
+			() => {
+				clearTimeout(timeoutId);
+				resolve();
+			},
+			(error?: unknown) => {
+				clearTimeout(timeoutId);
+				reject(error);
+			}
+		);
+	});
+}

--- a/packages/motion-start/src/animation/animators/waapi/NativeAnimation.ts
+++ b/packages/motion-start/src/animation/animators/waapi/NativeAnimation.ts
@@ -217,12 +217,21 @@ export class NativeAnimation implements AnimationPlaybackControls {
 	}
 
 	/**
+	 * A promise that resolves when the animation finishes. Only replaced when a
+	 * finished animation is replayed via play(), so awaiting an already-finished
+	 * animation resolves immediately.
+	 */
+	get finished(): Promise<void> {
+		return this.currentFinishedPromise;
+	}
+
+	/**
 	 * Allows the returned animation to be awaited or promise-chained. Currently
 	 * resolves when the animation finishes at all but in a future update could/should
 	 * reject if its cancels.
 	 */
 	then(resolve: VoidFunction, reject?: VoidFunction) {
-		return this.currentFinishedPromise.then(resolve, reject);
+		return this.finished.then(resolve, reject);
 	}
 
 	private updateFinishedPromise() {

--- a/packages/motion-start/src/animation/types.ts
+++ b/packages/motion-start/src/animation/types.ts
@@ -117,6 +117,11 @@ export interface AnimationPlaybackControls {
 	pause: () => void;
 	complete: () => void;
 	cancel: () => void;
+	/**
+	 * Resolves when the animation finishes. Optional so third-party
+	 * implementations of this interface remain valid.
+	 */
+	finished?: Promise<void>;
 	then: (onResolve: VoidFunction, onReject?: VoidFunction) => Promise<void>;
 	attachTimeline?: (
 		timeline: ProgressTimeline,


### PR DESCRIPTION
**Stacked PR — base is `jonathonrp-fix-animation-replay-and-speed` (#76), not `main`.** This depends on #76 and should be merged after it.

Ports the behavioural fix for upstream motiondivision/motion#3145 and motiondivision/motion#3144. No architectural refactor was attempted: upstream's #3148 rewrite (the `WithPromise` mixin, `GroupAnimation`/`GroupAnimationWithThen` split) is deliberately *not* included — the equivalent semantics are implemented inside the existing class structure.

## The bug

`MainThreadAnimation.teardown()` resolved the finished promise and then immediately replaced it with a fresh, unresolved one. Anything that awaited or chained the controls *after* the animation had completed waited forever, because `BaseAnimation.then` read `currentFinishedPromise` — by then the new, never-resolved instance. `GroupPlaybackControls.then` compounded it by passing the member controls to `Promise.all` as raw one-shot thenables.

## Changes

- **`BaseAnimation`** — adds a `finished` getter returning the current finished promise; `then()` now reads it fresh (`this.finished.then(...)`).
- **`MainThreadAnimation`** — `teardown()` resolves the finished promise but no longer recreates it; `cancel()` no longer recreates it either, so a cancelled animation still resolves its awaiters. The promise is recreated only in `play()` when replaying a finished animation (added in #76).
- **`AcceleratedAnimation`** — `stop()` resolves without recreating, since `isStopped` prevents the animation from ever being replayed. `play()` still recreates the promise for a finished WAAPI animation.
- **`NativeAnimation`** — adds the same `finished` getter and routes `then()` through it. Its existing resolve/recreate semantics were already correct and were left alone.
- **`GroupPlaybackControls`** — adds a `finished` getter that awaits each member's own `finished` promise, falling back to the member itself (a thenable) when it doesn't expose one, so third-party/legacy `AnimationPlaybackControls` implementations keep working. `then()` routes through it. An empty group (e.g. `new GroupPlaybackControls([])` from `animation/interfaces/motion-value.ts`) still resolves immediately.
- **`animation/types.ts`** — `AnimationPlaybackControls.finished` added as **optional** so existing implementors don't break.

## Regression tests

All new tests use a `withTimeout` helper (added to `animators/__tests__/utils.ts`) so a hang fails fast instead of stalling the suite.

`MainThreadAnimation.spec.ts` → `describe('finished promise')`:
1. `await` resolves once the animation completes
2. a second `await` after natural completion still resolves *(core bug)*
3. `.then()` fires after natural completion
4. replaying a finished animation creates a new finished promise
5. a cancelled animation resolves subsequent awaits
6. a stopped animation resolves subsequent awaits

`GroupPlaybackControls.spec.ts` → `describe('finished promise')`:
7. `await` resolves once all animations complete
8. a second `await` after natural completion still resolves
9. `.then()` fires after natural completion
10. an empty group resolves immediately
11. falls back to members that do not expose `finished`

Verified by `git stash`-ing only the source edits: **8 of these fail without the fix** (the rest exercise paths that were already correct or the new API surface), and all pass with it.

## Test results

- `bun run test:run` (full suite): **129 files passed, 1 skipped — 644 tests passed, 1 skipped, no type errors**
- `bun x vitest --run src/animation`: 24 files, 218 tests passed, no type errors
- No new biome lint violations in the touched files (remaining diagnostics are pre-existing: `noThenProperty`, `useOptionalChain`, CRLF format noise)
- `bun.lock` is not included in this PR