### PR TITLE
Reduce published package install size

### DIFF
--- a/.changeset/tidy-pandas-smile.md
+++ b/.changeset/tidy-pandas-smile.md
@@ -1,0 +1,5 @@
+---
+"motion-start": patch
+---
+
+Reduce the published package install size by excluding test fixtures and unusable declaration maps.

--- a/packages/motion-start/package.json
+++ b/packages/motion-start/package.json
@@ -71,6 +71,7 @@
 	},
 	"files": [
 		"dist",
+		"!dist/**/__tests__/**",
 		"!dist/**/*.test.*",
 		"!dist/**/*.spec.*"
 	],

--- a/packages/motion-start/tsconfig.json
+++ b/packages/motion-start/tsconfig.json
@@ -12,7 +12,7 @@
 		"skipLibCheck": true,
 		"verbatimModuleSyntax": true,
 		"declaration": true,
-		"declarationMap": true,
+		"declarationMap": false,
 		"types": ["vitest/globals", "node"]
 	},
 	"include": ["src/**/*.ts", "src/**/*.js", "src/**/*.svelte"],


### PR DESCRIPTION
## Summary

- exclude all generated `dist/**/__tests__/**` fixtures while retaining the existing named test/spec exclusions
- disable declaration-map emission while preserving declarations and the existing runtime `sourceMap` setting
- add a patch changeset for `motion-start`
- keep `csstype` as a runtime dependency so public declaration imports continue to resolve

## Direct package measurements

Measured against published `motion-start@0.2.0-next.6` and an actual tarball built from this branch:

| Metric | Published next.6 | This PR | Reduction |
| --- | ---: | ---: | ---: |
| Packed files | 1,354 | 829 | 525 (38.77%) |
| Tarball size | 344,327 bytes | 274,556 bytes | 69,771 bytes (20.26%) |
| Unpacked size | 1,396,010 bytes | 1,052,820 bytes | 343,190 bytes (24.58%) |

Tarball inspection confirms **0** `__tests__` paths and **0** `.d.ts.map` files.

## Installed dependency closure

npmx calculates install size as the sum of registry `dist.unpackedSize` for the root and recursively resolved runtime dependencies (excluding peer dependencies). Its published-version comparison is:

| Version | Root | Dependencies | Total |
| --- | ---: | ---: | ---: |
| `0.1.21` | 1,642,392 | 464,145 | 2,106,537 bytes |
| `0.2.0-next.6` | 1,396,010 | 1,689,997 | 3,086,007 bytes |
| This PR | 1,052,820 | 1,689,997 | 2,742,817 bytes |

This PR reduces the published next.6 total closure by **343,190 bytes (11.12%)**. Compared with v0.1.21, the candidate root package is **589,572 bytes (35.90%) smaller**, but its total closure remains **636,280 bytes (30.21%) larger** because dependencies are unchanged.

The exact **979,470-byte (46.50%)** next.6 regression shown by npmx is:

| Package change from v0.1.21 | Byte delta |
| --- | ---: |
| `csstype@3.2.3` added | +1,253,449 |
| `runed@0.37.1` added | +242,710 |
| `lz-string@1.5.0` added | +175,825 |
| `dequal@2.0.3` added | +14,229 |
| `esm-env@1.2.2` added | +3,784 |
| `motion-start` root changed | -246,382 |
| `popmotion@11.0.5` removed | -304,115 |
| `style-value-types@5.1.2` removed | -58,607 |
| `tslib@2.4.0` removed | -49,968 |
| `framesync@6.1.2` removed | -42,561 |
| `hey-listen@1.0.8` removed | -8,894 |
| **Net** | **+979,470** |

A clean npm install using `--legacy-peer-deps` to match npmx's runtime-only closure measured:

| Artifact | Files in `node_modules` | Bytes in `node_modules` |
| --- | ---: | ---: |
| v0.1.21 | 948 | 2,108,973 |
| Published next.6 | 1,569 | 3,090,214 |
| This PR tarball | 1,044 | 2,747,008 |

The small difference from npmx totals is npm-generated `.package-lock.json`/`.bin` content.

### Why `csstype` remains

Svelte 5.56.8's stable public `svelte/elements` surface does **not** export `CSSProperties` or `StyleProperties`; HTML and SVG `style` attributes are typed only as `string | null | undefined`. DOM's `CSSStyleDeclaration` similarly uses broad string values and cannot preserve `MotionStyle`'s property-specific unions, numeric lengths, MotionValue support, or generated public declaration behavior. Replacing `csstype` with either would weaken consumer types. Moving it to dev, optional, or peer dependencies would not safely solve declaration resolution or npm's default install closure, so this focused packaging PR intentionally retains it.

## Validation

- `bun run package` (includes `svelte-package` and `publint --strict`)
- `bun run test:run`: 143 passed, 1 skipped test file; 642 passed, 1 skipped test
- `bun run test:types`: 21 files and 21 tests passed; no type errors
- `bun run check:package`: 0 errors and 0 warnings
- clean npm consumer install from the generated tarball
- clean consumer TypeScript import check for `motion-start` and `motion-start/dom`
- package export targets resolve to `dist/index.js` and `dist/dom.js` under the Svelte condition
- actual tarball inspection: 829 entries, 0 `__tests__` paths, 0 `.d.ts.map` files

No release version files or `bun.lock` changes are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Reduced the published package size by excluding test fixtures and unusable declaration maps.
  - Added a patch release entry for these packaging improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->